### PR TITLE
ci(migrations): harden staging + production migration workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,7 @@ jobs:
 
           echo "Connecting to Supabase..."
 
-          # Get list of migration files
-          MIGRATION_FILES=$(ls -1 *.sql 2>/dev/null | sort || echo "")
+          MIGRATION_FILES=$(ls -1 *.sql | sort)
 
           if [ -z "$MIGRATION_FILES" ]; then
             echo "No migration files found"
@@ -71,10 +70,16 @@ jobs:
             exit 0
           fi
 
-          # Get already applied migrations
-          APPLIED_MIGRATIONS=$(psql -t -c "SELECT migration_name FROM schema_migrations ORDER BY migration_name;" 2>/dev/null || echo "")
+          # Ensure tracking table exists before SELECT — must succeed
+          psql -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS schema_migrations (
+            id SERIAL PRIMARY KEY,
+            migration_name VARCHAR(255) UNIQUE NOT NULL,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+          );"
 
-          # Find pending migrations
+          # Connection/SQL errors must surface — no stderr suppression
+          APPLIED_MIGRATIONS=$(psql -v ON_ERROR_STOP=1 -t -c "SELECT migration_name FROM schema_migrations ORDER BY migration_name;")
+
           PENDING_MIGRATIONS=""
           for migration in $MIGRATION_FILES; do
             if ! echo "$APPLIED_MIGRATIONS" | grep -q "$migration"; then
@@ -103,20 +108,11 @@ jobs:
         run: |
           cd DB/migrations
 
-          # Create schema_migrations table if it doesn't exist
-          echo "Creating schema_migrations table..."
-          psql -c "CREATE TABLE IF NOT EXISTS schema_migrations (
-            id SERIAL PRIMARY KEY,
-            migration_name VARCHAR(255) UNIQUE NOT NULL,
-            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-          );"
-
-          # Run each pending migration
           for migration in ${{ steps.check_migrations.outputs.pending_list }}; do
             echo "▶️  Running migration: $migration"
 
-            if psql -f "$migration"; then
-              psql -c "INSERT INTO schema_migrations (migration_name) VALUES ('$migration');"
+            if psql -v ON_ERROR_STOP=1 -f "$migration"; then
+              psql -v ON_ERROR_STOP=1 -c "INSERT INTO schema_migrations (migration_name) VALUES ('$migration');"
               echo "Migration $migration completed"
             else
               echo "Migration $migration failed"

--- a/.github/workflows/staging-backend.yml
+++ b/.github/workflows/staging-backend.yml
@@ -39,25 +39,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y postgresql-client
 
-      - name: Debug connection params
-        env:
-          PGPASSWORD: ${{ secrets.PGPASSWORD }}
-          PGHOST: ${{ secrets.PGHOST }}
-          PGUSER: ${{ secrets.PGUSER }}
-          PGDATABASE: ${{ secrets.PGDATABASE || 'postgres' }}
-        run: |
-          echo "PGHOST length:     ${#PGHOST}"
-          echo "PGHOST first 4:    ${PGHOST:0:4}"
-          echo "PGHOST contains pooler: $(echo "$PGHOST" | grep -q 'pooler' && echo yes || echo no)"
-          echo "PGUSER length:     ${#PGUSER}"
-          echo "PGUSER has dot:    $(echo "$PGUSER" | grep -q '\.' && echo yes || echo no)"
-          echo "PGUSER first 9:    ${PGUSER:0:9}"
-          echo "PGPASSWORD length: ${#PGPASSWORD}"
-          echo "PGDATABASE:        $PGDATABASE"
-          echo ""
-          echo "Resolving host (IPv4 only)..."
-          getent ahostsv4 "$PGHOST" | head -1 || echo "no IPv4 resolution"
-
       - name: Check for pending migrations
         id: check_migrations
         env:
@@ -72,7 +53,7 @@ jobs:
 
           echo "Connecting to Supabase staging..."
 
-          MIGRATION_FILES=$(ls -1 *.sql 2>/dev/null | sort || echo "")
+          MIGRATION_FILES=$(ls -1 *.sql | sort)
 
           if [ -z "$MIGRATION_FILES" ]; then
             echo "No migration files found"
@@ -80,7 +61,15 @@ jobs:
             exit 0
           fi
 
-          APPLIED_MIGRATIONS=$(psql -t -c "SELECT migration_name FROM schema_migrations ORDER BY migration_name;" 2>/dev/null || echo "")
+          # Ensure tracking table exists before SELECT — must succeed
+          psql -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS schema_migrations (
+            id SERIAL PRIMARY KEY,
+            migration_name VARCHAR(255) UNIQUE NOT NULL,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+          );"
+
+          # Connection/SQL errors must surface — no stderr suppression
+          APPLIED_MIGRATIONS=$(psql -v ON_ERROR_STOP=1 -t -c "SELECT migration_name FROM schema_migrations ORDER BY migration_name;")
 
           PENDING_MIGRATIONS=""
           for migration in $MIGRATION_FILES; do
@@ -110,17 +99,11 @@ jobs:
         run: |
           cd DB/migrations
 
-          psql -c "CREATE TABLE IF NOT EXISTS schema_migrations (
-            id SERIAL PRIMARY KEY,
-            migration_name VARCHAR(255) UNIQUE NOT NULL,
-            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-          );"
-
           for migration in ${{ steps.check_migrations.outputs.pending_list }}; do
             echo "▶️  Running migration: $migration"
 
-            if psql -f "$migration"; then
-              psql -c "INSERT INTO schema_migrations (migration_name) VALUES ('$migration');"
+            if psql -v ON_ERROR_STOP=1 -f "$migration"; then
+              psql -v ON_ERROR_STOP=1 -c "INSERT INTO schema_migrations (migration_name) VALUES ('$migration');"
               echo "Migration $migration completed"
             else
               echo "Migration $migration failed"

--- a/docs/daily-progress/2026-04-29-migration-workflow-hardening.md
+++ b/docs/daily-progress/2026-04-29-migration-workflow-hardening.md
@@ -1,0 +1,50 @@
+# 2026-04-29: DB Migration Workflow Hardening
+
+**Branch**: `feature/update-workflow`
+**Status**: Done
+
+---
+
+## Overview
+
+Hardened both staging and production DB migration workflows after the first staging run revealed two failure modes that masked real problems: silently swallowed connection errors and per-statement SQL errors that didn't fail the migration. Also resolved the underlying connection issue (Supabase pooler IPv4 vs direct IPv6 host).
+
+---
+
+## Context
+
+The first staging run hit `psql: connection ... Network is unreachable` because GitHub Actions runners are IPv4-only and the direct Supabase host (`db.<ref>.supabase.co:5432`) only resolves to IPv6 on the free plan. After switching `PGHOST`/`PGUSER` secrets to the Supavisor pooler (`aws-0-eu-west-1.pooler.supabase.com`, user `postgres.<ref>`) the connection worked, but the run still applied all 53 migrations because:
+
+1. The `schema_migrations` SELECT was wrapped in `2>/dev/null || echo ""`, so a transient auth failure produced an empty applied-list and the workflow assumed everything was pending.
+2. `psql -f migration.sql` returns exit code 0 even when individual statements inside the file fail, so visible `ERROR: ... already exists` lines were ignored and the migrations were marked complete anyway.
+
+---
+
+## Changes
+
+### CI/CD
+
+#### `.github/workflows/staging-backend.yml`
+- Removed temporary "Debug connection params" step that was used to diagnose the pooler auth failure.
+- Moved `CREATE TABLE IF NOT EXISTS schema_migrations` from the run step into the check step, before the `SELECT` — so the SELECT can no longer fail for "table missing", only for real connection/SQL issues.
+- Removed `2>/dev/null || echo ""` wrappers from `ls` and the `SELECT migration_name` query — connection/SQL errors now surface in the logs instead of being silently dropped.
+- Added `-v ON_ERROR_STOP=1` to every `psql` invocation (CREATE, SELECT, `-f migration.sql`, INSERT into `schema_migrations`). Any failing statement inside a migration file now aborts that file and fails the job.
+
+#### `.github/workflows/deploy.yml`
+- Same hardening applied to the production workflow (it shared the same fragile logic). No debug step to remove there.
+
+---
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `.github/workflows/staging-backend.yml` | Removed debug step, hardened check + run steps |
+| `.github/workflows/deploy.yml` | Hardened check + run steps |
+
+---
+
+## Follow-up (out of scope)
+
+- Plan a migration to **Supabase CLI native migrations** (`supabase db push`). The current homemade system has duplicate prefixes (`011_*` x2, `012_*` x2, …) and a missing `023` that would need to be resolved as part of that move. Estimated ~1 day of work; tracked separately.
+- The `/new-migration` and `/run-migration` slash commands referenced in `CLAUDE.md` aren't actually defined in `.claude/commands/`; either implement them or remove from the docs.


### PR DESCRIPTION
## Summary

- Add `-v ON_ERROR_STOP=1` to every psql call in both `staging-backend.yml` and `deploy.yml` so individual SQL errors inside a migration file actually fail the job (previously psql exited 0 on per-statement errors).
- Stop swallowing connection/auth failures: removed `2>/dev/null || echo ""` around the `SELECT migration_name FROM schema_migrations` query. A transient auth error no longer produces a phantom empty applied-list that re-runs every migration.
- Move `CREATE TABLE IF NOT EXISTS schema_migrations` into the check step, before the SELECT, so the query only fails for real reasons (missing-table is no longer ambiguous with auth failures).
- Drop the temporary "Debug connection params" step from staging — the Supavisor pooler credentials (`PGHOST = aws-0-eu-west-1.pooler.supabase.com`, `PGUSER = postgres.<ref>`) have been validated.

Background: GitHub runners are IPv4-only, and the direct Supabase host (`db.<ref>.supabase.co:5432`) only resolves to IPv6 on the free plan, so the pooler is required. See `docs/daily-progress/2026-04-29-migration-workflow-hardening.md`.

## Test plan

- [ ] Merge → triggers `Staging Backend Deploy` on main → expected: "Check" step prints `No pending migrations found`, "Run" step is skipped, deploy proceeds
- [ ] (optional, before-merge fail-loud test) flip `PGPASSWORD` to a wrong value via `workflow_dispatch` → expected: visible `password authentication failed` error in logs (no longer masked)
- [ ] Next production tag `v*` exercises the same hardened logic on `deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)