### PR TITLE
fix(docker): bump Rust base image from 1.85 to 1.88

### DIFF
--- a/rust_BE/Dockerfile
+++ b/rust_BE/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.85-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Cargo.lock (regenerated in PR#33) pulls in transitive deps that require
Rust ≥ 1.88 (time 0.3.47, home 0.5.12, time-core 0.1.8, time-macros 0.2.27)
and ≥ 1.86 (icu_* 2.2.0, idna_adapter 1.2.2). The old rust:1.85-slim image
caused the Fly.io remote build to fail immediately after cargo fetch --locked.

https://claude.ai/code/session_01XcAcGzSige366ygjrQrLxS