### PR TITLE
fix(app): migliora visual della EventCard home screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,5 +195,8 @@ Payment mutations accept an `Idempotency-Key` header. The `IdempotencyService` s
 
 ## Workflow
 
+### Pull requests e issue linking
+Whenever creating a PR that resolves a GitHub issue, always include `Closes #<issue-number>` (or `Fixes #` / `Resolves #`) in the PR body so the issue is auto-closed on merge.
+
 ### Before committing
 Always propose updating (or creating) the daily progress log in `docs/daily-progress/` before creating a git commit. File name format: `YYYY-MM-DD-<short-slug>.md`. Follow the structure of existing files in that folder: Overview → Changes grouped by layer (Backend / Dashboard / Mobile / Database) → Files Modified table.

--- a/pierre_two/app/(tabs)/index.tsx
+++ b/pierre_two/app/(tabs)/index.tsx
@@ -462,7 +462,7 @@ const styles = StyleSheet.create({
     paddingBottom: 48,
   },
   topIntro: {
-    paddingHorizontal: 16,
+    paddingHorizontal: 14,
     marginBottom: 18,
   },
   topIntroRow: {
@@ -496,7 +496,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   dateSection: {
-    marginHorizontal: 16,
+    marginHorizontal: 14,
     marginBottom: 18,
     paddingTop: 8,
     paddingBottom: 2,
@@ -505,14 +505,14 @@ const styles = StyleSheet.create({
     height: 3,
     width: 56,
     borderRadius: 999,
-    marginLeft: 16,
+    marginLeft: 14,
     marginBottom: 12,
   },
   dateHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingHorizontal: 16,
+    paddingHorizontal: 14,
     marginBottom: 10,
   },
   dateHeaderCopy: {
@@ -547,7 +547,7 @@ const styles = StyleSheet.create({
   },
   eventsRow: {},
   eventsRowContent: {
-    paddingLeft: 16,
+    paddingLeft: 14,
     paddingRight: 28,
     paddingBottom: 8,
   },

--- a/pierre_two/components/home/EventCard.tsx
+++ b/pierre_two/components/home/EventCard.tsx
@@ -11,12 +11,9 @@ type EventCardProps = {
 };
 
 const formatEventTime = (event: Event) => {
-  // Prefer the time field if available
   if (event.time) {
     return event.time;
   }
-
-  // Fallback to parsing the date field
   try {
     const date = new Date(event.date);
     const hours = date.getHours().toString().padStart(2, '0');
@@ -24,6 +21,17 @@ const formatEventTime = (event: Event) => {
     return `${hours}:${minutes}`;
   } catch (e) {
     return '';
+  }
+};
+
+const formatEventDate = (dateStr: string) => {
+  const days = ['Dom', 'Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab'];
+  const months = ['Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu', 'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'];
+  try {
+    const date = new Date(dateStr);
+    return `${days[date.getDay()]} ${date.getDate()} ${months[date.getMonth()]}`;
+  } catch (e) {
+    return dateStr;
   }
 };
 
@@ -95,12 +103,6 @@ export const EventCard = ({ event, onPress }: EventCardProps) => {
             <ThemedText style={[styles.timeBadgeText, { color: theme.text }]}>{formatEventTime(event)}</ThemedText>
           </View>
         </View>
-        {event.status && (
-          <View style={[styles.statusBadge, { backgroundColor: theme.error }]}>
-            <ThemedText style={styles.statusText}>{event.status}</ThemedText>
-          </View>
-        )}
-
         <View
           style={[
             styles.infoPanel,
@@ -110,17 +112,13 @@ export const EventCard = ({ event, onPress }: EventCardProps) => {
             },
           ]}
         >
-          <View style={styles.kickerRow}>
-            <ThemedText style={[styles.kickerText, { color: theme.primary }]}>
-              Evento in evidenza
-            </ThemedText>
-            <ThemedText style={[styles.kickerDivider, { color: theme.textTertiary }]}>
-              •
-            </ThemedText>
-            <ThemedText style={[styles.kickerText, { color: theme.textTertiary }]}>
-              {event.status || 'Disponibile'}
-            </ThemedText>
-          </View>
+          {event.status && (
+            <View style={styles.kickerRow}>
+              <ThemedText style={[styles.kickerText, { color: theme.error }]}>
+                {event.status}
+              </ThemedText>
+            </View>
+          )}
           <View style={styles.titleRow}>
             <ThemedText style={[styles.eventTitle, { color: theme.text }]} numberOfLines={2}>
               {event.title}
@@ -139,26 +137,8 @@ export const EventCard = ({ event, onPress }: EventCardProps) => {
           <View style={styles.metaRow}>
             <IconSymbol name="calendar" size={13} color={theme.textTertiary} />
             <ThemedText style={[styles.metaText, { color: theme.textTertiary }]} numberOfLines={1}>
-              {event.date}
+              {formatEventDate(event.date)}
             </ThemedText>
-          </View>
-
-          {event.genres && event.genres.length > 0 && (
-            <View style={styles.genreRow}>
-              {event.genres.map(g => (
-                <View key={g.id} style={[styles.genreBadge, { backgroundColor: g.color }]}>
-                  <ThemedText style={styles.genreBadgeText}>{g.name}</ThemedText>
-                </View>
-              ))}
-            </View>
-          )}
-
-          <View style={styles.footerRow}>
-            <View style={[styles.ctaPill, { backgroundColor: theme.primary }]}>
-              <ThemedText style={[styles.ctaText, { color: theme.textInverse }]}>
-                Apri evento
-              </ThemedText>
-            </View>
           </View>
         </View>
       </View>
@@ -212,15 +192,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  statusBadge: {
-    position: 'absolute',
-    top: 16,
-    right: 16,
-    paddingHorizontal: 14,
-    paddingVertical: 7,
-    borderRadius: 20,
-    zIndex: 2,
-  },
   timeBadge: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -235,16 +206,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '700',
   },
-  statusText: {
-    color: '#fff',
-    fontSize: 12,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  eventInfo: {
-    position: 'absolute',
-  },
   infoPanel: {
     position: 'absolute',
     left: 16,
@@ -255,19 +216,13 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   kickerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    marginBottom: 8,
+    marginBottom: 6,
   },
   kickerText: {
     fontSize: 10,
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 0.7,
-  },
-  kickerDivider: {
-    fontSize: 10,
   },
   titleRow: {
     marginBottom: 10,
@@ -287,39 +242,5 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 13,
     fontWeight: '500',
-  },
-  genreRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
-    marginTop: 8,
-  },
-  genreBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 999,
-  },
-  genreBadgeText: {
-    color: '#fff',
-    fontSize: 10,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  footerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: 16,
-  },
-  ctaPill: {
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 999,
-  },
-  ctaText: {
-    fontSize: 11,
-    fontWeight: '800',
-    textTransform: 'uppercase',
-    letterSpacing: 0.6,
   },
 });


### PR DESCRIPTION
Closes #41

## Modifiche
- Rimosso testo "Evento in evidenza" hardcoded — lo status appare solo se presente nel dato (colore error)
- Eliminato `statusBadge` assoluto che andava in overlap con il `timeBadge` in alto a destra
- Data formattata con `formatEventDate` (es. "Ven 30 Apr") invece della stringa ISO grezza
- Rimosso pulsante "Apri evento" — la card intera è già tappable
- Rimossi tag genere dalla card (da mostrare solo nel dettaglio evento)

https://claude.ai/code/session_01WGDy1U3kh3BHsSv15hJaYg