### PR TITLE
fix(app): crash Marzipano sul cambio scena (clearHotspots dopo switchTo)

### DIFF
--- a/docs/daily-progress/2026-05-05-marzipano-scene-switch-crash.md
+++ b/docs/daily-progress/2026-05-05-marzipano-scene-switch-crash.md
@@ -1,0 +1,75 @@
+# 2026-05-05: Fix crash Marzipano sul cambio scena
+
+**Branch**: `fix/marzipano-viewer-scene-switch-crash`
+**Status**: Done — fix client-side al `viewer.html`, da verificare in app
+
+---
+
+## Overview
+
+Cliccando su un hotspot di tipo "scene-link" (link verso un'altra area del
+tour 360°), il viewer crashava con:
+
+```
+setTimeout error: undefined is not an object (evaluating 'e.style')
+```
+
+Schermata di errore "Failed to Load 360° Tour", riproducibile da più eventi.
+
+L'errore si verificava sia su scene-link cliccati (hotspot) sia sui cambi
+scena pilotati da React Native via `window.switchToScene` (es. menu
+hamburger), perché entrambi i path avevano lo stesso pattern bacato.
+
+---
+
+## Root cause
+
+Marzipano gestisce gli hotspot agganciandoli al `hotspotContainer` di una
+scena e ne aggiorna periodicamente lo stile per riposizionarli nello spazio
+3D durante una transizione. Il viewer chiamava `clearHotspots()` (che fa
+`instance.destroy()` su ogni hotspot) **prima** di `scene.switchTo({
+transitionDuration: 500 })`, mentre Marzipano stava ancora animando la
+transizione di 500 ms. Al primo `setTimeout` interno di Marzipano dopo la
+distruzione, `e.style` era `undefined` → eccezione, catturata dal nostro
+`try/catch` e propagata come "ERROR" alla UI.
+
+Lo stesso pattern era anche nella branch "subsequent switches" di
+`switchToScene`, con un'aggravante: `scene.switchTo` veniva chiamato senza
+callback e `createHotspots` partiva subito dopo, generando una race
+condition con la transizione.
+
+---
+
+## Fix
+
+In entrambi i path:
+
+- `clearHotspots()` spostato **dentro** il callback di completamento di
+  `scene.switchTo`, eseguito quando Marzipano ha finito la transizione e
+  rilasciato i suoi reference agli elementi DOM degli hotspot.
+- `createHotspots()` rimane post-switch, ma ora arriva nello stesso callback
+  (subito dopo `clearHotspots`) — niente più race tra creazione nuovi e
+  transizione in corso.
+- `scene.switchTo` nella branch "subsequent" ora riceve un callback
+  esplicito, allineandosi al path scene-link.
+- Aggiunto un commento sul perché del pattern, per evitare che un futuro
+  refactor reintroduca l'ordine "destroy → switch".
+
+---
+
+## Files Modified
+
+| File | Modifica |
+|---|---|
+| `pierre_two/assets/marzipano/viewer.html` | `handleSceneLinkClick`: clearHotspots spostato dentro callback `switchTo`; `switchToScene` (subsequent branch): aggiunto callback a `switchTo` con clearHotspots/createHotspots all'interno |
+
+---
+
+## Verifica
+
+- Aprire un evento con tour 360 multi-scena (es. "Prezioso" → fallback dal
+  club "Test Club") → "Prenota tavolo" → cliccare uno scene-link.
+- Stesso test usando il menu hamburger per saltare a un'altra area.
+- Il viewer deve completare la transizione senza errori, mostrare il nome
+  della nuova scena nell'indicatore in alto a destra, e ripopolare gli
+  hotspot tavolo della nuova area.

--- a/pierre_two/assets/marzipano/viewer.html
+++ b/pierre_two/assets/marzipano/viewer.html
@@ -569,24 +569,37 @@
         isSwitching = false;
         console.log('🔄 Scene change notified');
       } else {
-        // Existing fade logic for subsequent switches
+        // Existing fade logic for subsequent switches.
+        // Same constraint as handleSceneLinkClick: do NOT clearHotspots()
+        // before scene.switchTo finishes — Marzipano still ticks the old
+        // hotspot DOM during the transition and crashes if the elements
+        // disappear underneath it. Clear/create inside the completion cb.
         const panoElement = document.getElementById('pano');
         panoElement.style.opacity = '0';
 
         setTimeout(() => {
-          clearHotspots();
-          scene.switchTo({ transitionDuration: 500 });
-          currentHotspotContainer = scene.hotspotContainer();
-          currentSceneId = sceneId;
-          updateSceneIndicator(sceneConfig.name);
-          createHotspots(sceneConfig.hotspots || []);
-          panoElement.style.opacity = '1';
-          notifyReactNative({
-            type: 'SCENE_CHANGE',
-            sceneId: sceneId,
-            sceneName: sceneConfig.name
-          });
-          isSwitching = false;
+          try {
+            scene.switchTo({ transitionDuration: 500 }, function() {
+              clearHotspots();
+              currentHotspotContainer = scene.hotspotContainer();
+              currentSceneId = sceneId;
+              updateSceneIndicator(sceneConfig.name);
+              createHotspots(sceneConfig.hotspots || []);
+
+              setTimeout(() => {
+                panoElement.style.opacity = '1';
+                notifyReactNative({
+                  type: 'SCENE_CHANGE',
+                  sceneId: sceneId,
+                  sceneName: sceneConfig.name
+                });
+                isSwitching = false;
+              }, 100);
+            });
+          } catch (error) {
+            notifyReactNative({ type: 'ERROR', message: '❌ switchToScene timeout error: ' + error.message });
+            isSwitching = false;
+          }
         }, 300);
       }
       } catch (error) {
@@ -788,12 +801,16 @@
         setTimeout(() => {
           try {
             notifyReactNative({ type: 'DEBUG', message: '🔄 Switching scene in timeout...' });
-            notifyReactNative({ type: 'DEBUG', message: '🔄 About to call clearHotspots...' });
-            clearHotspots();
-            notifyReactNative({ type: 'DEBUG', message: '🔄 clearHotspots returned successfully' });
             notifyReactNative({ type: 'DEBUG', message: '🔄 Calling scene.switchTo...' });
+            // Note: don't destroy old hotspots before switchTo. Marzipano keeps
+            // ticking the old hotspot DOM during the transition (positioning
+            // them in 3D), so destroying them mid-transition crashes its
+            // setTimeout-driven internals with `undefined is not an object
+            // (evaluating 'e.style')`. Clear them inside the completion
+            // callback once the transition is done.
             scene.switchTo({ transitionDuration: 500 }, function() {
               notifyReactNative({ type: 'DEBUG', message: '🔄 Scene transition complete, setting up hotspots...' });
+              clearHotspots();
               currentHotspotContainer = scene.hotspotContainer();
               currentSceneId = targetSceneId;
               updateSceneIndicator(sceneConfig.name);


### PR DESCRIPTION
## Summary

Cliccando uno scene-link nel tour 360° (o cambiando scena dal menu) il viewer crashava con:

> `setTimeout error: undefined is not an object (evaluating 'e.style')`

→ schermata "Failed to Load 360° Tour", riproducibile su più eventi (segnalato dopo il merge di #43, su staging).

## Root cause

`clearHotspots()` veniva eseguito **prima** di `scene.switchTo({ transitionDuration: 500 })`. Marzipano però continua a tickare il DOM degli hotspot durante la transizione (per riposizionarli in 3D). Distruggere quegli elementi sotto la transizione in corso fa esplodere il suo `setTimeout` interno al primo accesso a `e.style`.

Stesso pattern era anche nella branch "subsequent switches" di `switchToScene`, con in più la chiamata a `switchTo` senza callback e `createHotspots` lanciato subito dopo (race con la transizione di 500ms).

## Fix

In entrambi i path (`handleSceneLinkClick` e `switchToScene` ramo "subsequent"):

- `clearHotspots()` spostato **dentro** la callback di completamento di `scene.switchTo`, dopo che Marzipano ha rilasciato i reference agli elementi DOM.
- `createHotspots()` rimane subito dopo `clearHotspots`, sempre nella stessa callback → niente più race con la transizione.
- Aggiunto callback esplicito al `switchTo` nel ramo "subsequent" (prima girava fire-and-forget).
- Commenti inline sul perché dell'ordine, così un futuro refactor non reintroduca "destroy → switch".

## Test plan

- [ ] Build dev su Expo
- [ ] Aprire un evento con tour multi-scena (es. "Prezioso" / "AAAAA" su staging — il fallback club di #43 li copre) → "Prenota tavolo"
- [ ] Cliccare uno scene-link → la transizione completa, l'indicatore scena si aggiorna, gli hotspot tavolo della nuova area appaiono, niente errore
- [ ] Stesso test pilotando il cambio scena dal menu hamburger
- [ ] Verifica regressione: l'inizializzazione della prima scena continua a funzionare (path separato, non toccato)

🤖 Generated with [Claude Code](https://claude.com/claude-code)