### PR TITLE
fix(dashboard): owner UX bugfixes, club info refresh & image upload

### DIFF
--- a/docs/daily-progress/2026-05-06-dashboard-bugfixes.md
+++ b/docs/daily-progress/2026-05-06-dashboard-bugfixes.md
@@ -1,0 +1,111 @@
+# 2026-05-06: Dashboard bugfixes & club info refresh
+
+**Branch**: `develop`
+**Status**: Done — `cargo check` ✅, `tsc --noEmit` ✅
+
+---
+
+## Overview
+
+A round of UX/data-flow bugfixes on the club-owner dashboard, plus two
+underlying issues that were silently breaking persistence:
+
+1. **Sidebar** — "Impostazioni Locale" stayed highlighted while on
+   `/dashboard/club/areas` because its `NavLink` matched by prefix.
+2. **EventsPage filter** — date filter sat in its own `SectionCard`,
+   stacked above "Nuovo evento", and was lost on reload.
+3. **EventsPage** — no quick way to jump to per-event 360° tour config.
+4. **EventReservationsPage** — header didn't show which event the
+   reservations belonged to.
+5. **Manual reservation modal** — no tables selectable after the
+   club-level areas/tables migration: the per-event endpoint filters
+   `WHERE t.event_id = $1`, but new tables have `event_id IS NULL`.
+6. **Tour 360 navigation** — promoted the club-level configurator from a
+   button buried in Impostazioni Locale to its own sidebar entry.
+7. **Stale localStorage** — `AuthProvider` only wrote to localStorage on
+   login; updating the club from the settings page left the cached copy
+   (and therefore the sidebar) out of date.
+8. **Club image** — there was no UI to change the club image, and
+   `OwnerUpdateClubRequest` hardcoded `image: None`.
+9. **Club address/phone/website not surfacing** — `ClubResponse` was
+   missing those fields entirely, so the form reloaded empty even though
+   the DB had them. Felt like "the address isn't being saved".
+10. **Galleria immagini** — hidden temporarily to deprioritize gallery
+    work in favor of the 360° tour configuration.
+
+---
+
+## Changes
+
+### Backend
+
+- **`rust_BE/src/models/club.rs`** — `ClubResponse` now exposes
+  `address`, `phone_number`, `website` (all `Option<String>`,
+  `skip_serializing_if = "Option::is_none"`); `From<Club>` maps them
+  through. Fixes the symptom where saved info appeared lost on reload.
+- **`rust_BE/src/models/club_owner.rs`** — `OwnerUpdateClubRequest`
+  gains an optional `image` field so the dashboard can update the club
+  image via PUT `/owner/club`.
+- **`rust_BE/src/controllers/club_owner_controller.rs`** —
+  - `update_my_club` forwards `payload.image` to `UpdateClubRequest`
+    instead of hardcoding `None`.
+  - `get_my_club_tables` now merges `get_tables_by_event_id` (legacy
+    event-bound) with `get_tables_by_club_id` (club-level tables for the
+    owner's club) so the per-event endpoint returns both sets. Without
+    this, the manual-reservation modal was empty after the club-level
+    tables migration.
+
+### Dashboard
+
+- **`pierre_dashboard/src/components/Sidebar.tsx`** —
+  - `NavLink` for "Impostazioni Locale" now uses `end` so it isn't
+    highlighted when the route is `/dashboard/club/areas`.
+  - New "Tour 360° locale" entry (icon `Compass`) → `/dashboard/club/tour`,
+    promoting the action out of the settings page header.
+- **`pierre_dashboard/src/context/AuthContext.tsx`** — exposes
+  `setClub(club)` and `setOwner(owner)` that update both React state and
+  `localStorage`. Internal renames to `setOwnerState` / `setClubState`
+  to keep the public API clean. Lets pages refresh the cached profile
+  after a successful PUT.
+- **`pierre_dashboard/src/pages/EventsPage.tsx`** —
+  - Date filter is now an inline `<input type="date">` (`w-37.5`) inside
+    the `PageHeader` action, on the same row as "Nuovo evento"
+    (`whitespace-nowrap`). Removed the surrounding `SectionCard`.
+  - Filter date persists in the URL via `useSearchParams` (`?from=...`).
+  - Each event card has a new "Tour 360" button (matching `<button>` —
+    not `<Link>` — to share the same `font: inherit` reset and avoid the
+    smaller-anchor visual mismatch); navigation handled with
+    `useNavigate`.
+- **`pierre_dashboard/src/pages/EventReservationsPage.tsx`** —
+  - Fetches the event via `GET /events/:id` and shows
+    `Prenotazioni · {title}` as the page title with
+    `{date · time · venue}` (Italian-formatted via `Intl.DateTimeFormat`)
+    as the description.
+- **`pierre_dashboard/src/pages/ClubSettingsPage.tsx`** —
+  - Removed the gallery section, its handlers (`handleAddImage`,
+    `handleDeleteImage`), the `/owner/club/images` fetch, and all
+    related state. Backend endpoints untouched.
+  - Added a club-image upload as the first form field, reusing
+    `EventImageUpload` which posts to `/owner/events/image` and returns
+    a URL.
+  - On successful PUT, parses the response as `Club` and calls
+    `persistClub(updatedClub)` so the sidebar (and any other consumer of
+    `useAuth().club`) reflects the change immediately, in addition to
+    refetching.
+  - Removed the "Configura tour 360°" button from the page header
+    (replaced by the sidebar entry).
+
+---
+
+## Files Modified
+
+| Layer | File | Note |
+|---|---|---|
+| Backend | `rust_BE/src/models/club.rs` | `ClubResponse` now serializes address/phone/website |
+| Backend | `rust_BE/src/models/club_owner.rs` | Add `image` to `OwnerUpdateClubRequest` |
+| Backend | `rust_BE/src/controllers/club_owner_controller.rs` | Forward image; merge club + event tables |
+| Dashboard | `pierre_dashboard/src/components/Sidebar.tsx` | `end` on settings link; new Tour 360 entry |
+| Dashboard | `pierre_dashboard/src/context/AuthContext.tsx` | Expose `setClub` / `setOwner` (state + localStorage) |
+| Dashboard | `pierre_dashboard/src/pages/EventsPage.tsx` | Inline date filter, querystring, Tour 360 button |
+| Dashboard | `pierre_dashboard/src/pages/EventReservationsPage.tsx` | Show event title + date in header |
+| Dashboard | `pierre_dashboard/src/pages/ClubSettingsPage.tsx` | Image upload, AuthContext refresh, hide gallery |

--- a/pierre_dashboard/src/components/Sidebar.tsx
+++ b/pierre_dashboard/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { LayoutDashboard, CalendarDays, LogOut, Settings, QrCode, X, LayoutGrid } from 'lucide-react';
+import { LayoutDashboard, CalendarDays, LogOut, Settings, QrCode, X, LayoutGrid, Compass } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { getSafeImageUrl } from '../utils/image';
 
@@ -61,12 +61,17 @@ function SidebarContent({ onClose }: { onClose?: () => void }) {
           Aree e tavoli
         </NavLink>
 
+        <NavLink to="/dashboard/club/tour" className={navLinkClass} onClick={onClose}>
+          <Compass size={20} />
+          Tour 360° locale
+        </NavLink>
+
         <NavLink to="/dashboard/scan" className={navLinkClass} onClick={onClose}>
           <QrCode size={20} />
           Scanner QR
         </NavLink>
 
-        <NavLink to="/dashboard/club" className={navLinkClass} onClick={onClose}>
+        <NavLink to="/dashboard/club" end className={navLinkClass} onClick={onClose}>
           <Settings size={20} />
           Impostazioni Locale
         </NavLink>

--- a/pierre_dashboard/src/context/AuthContext.tsx
+++ b/pierre_dashboard/src/context/AuthContext.tsx
@@ -10,16 +10,28 @@ interface AuthContextType {
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
+  setClub: (club: Club) => void;
+  setOwner: (owner: ClubOwner) => void;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
-  const [owner, setOwner] = useState<ClubOwner | null>(null);
-  const [club, setClub] = useState<Club | null>(null);
+  const [owner, setOwnerState] = useState<ClubOwner | null>(null);
+  const [club, setClubState] = useState<Club | null>(null);
   const [loading, setLoading] = useState(true);
   const previousOwnerIdRef = useRef<string | null>(null);
+
+  const setClub = (next: Club) => {
+    setClubState(next);
+    localStorage.setItem('auth_club', JSON.stringify(next));
+  };
+
+  const setOwner = (next: ClubOwner) => {
+    setOwnerState(next);
+    localStorage.setItem('auth_owner', JSON.stringify(next));
+  };
 
   useEffect(() => {
     const savedToken = localStorage.getItem('auth_token');
@@ -28,8 +40,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (savedToken && savedOwner) {
       setToken(savedToken);
-      setOwner(JSON.parse(savedOwner));
-      if (savedClub) setClub(JSON.parse(savedClub));
+      setOwnerState(JSON.parse(savedOwner));
+      if (savedClub) setClubState(JSON.parse(savedClub));
     }
     setLoading(false);
   }, []);
@@ -70,8 +82,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const data: AuthResponse = await res.json();
 
     setToken(data.token);
-    setOwner(data.owner);
-    setClub(data.club);
+    setOwnerState(data.owner);
+    setClubState(data.club);
 
     localStorage.setItem('auth_token', data.token);
     localStorage.setItem('auth_owner', JSON.stringify(data.owner));
@@ -93,8 +105,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     setToken(null);
-    setOwner(null);
-    setClub(null);
+    setOwnerState(null);
+    setClubState(null);
     localStorage.removeItem('auth_token');
     localStorage.removeItem('auth_owner');
     localStorage.removeItem('auth_club');
@@ -103,7 +115,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   if (loading) return null;
 
   return (
-    <AuthContext.Provider value={{ token, owner, club, isAuthenticated: !!token, login, logout }}>
+    <AuthContext.Provider value={{ token, owner, club, isAuthenticated: !!token, login, logout, setClub, setOwner }}>
       {children}
     </AuthContext.Provider>
   );

--- a/pierre_dashboard/src/pages/ClubSettingsPage.tsx
+++ b/pierre_dashboard/src/pages/ClubSettingsPage.tsx
@@ -4,41 +4,21 @@ import {
   CheckCircle2,
   CreditCard,
   ExternalLink,
-  Plus,
   RefreshCw,
   Save,
-  Trash2,
-  X,
 } from 'lucide-react';
 import { useFetch } from '../hooks/useFetch';
 import { useAuth } from '../context/AuthContext';
 import { API_URL } from '../config/api';
 import type {
   Club,
-  ClubImage,
   StripeConnectStatus,
   StripeOnboardingLinkResponse,
 } from '../types';
 import { trackEvent } from '../config/analytics';
-
-interface ClubImageApiRow {
-  id: string;
-  club_id?: string;
-  clubId?: string;
-  url: string;
-  display_order?: number;
-  displayOrder?: number;
-  alt_text?: string | null;
-  altText?: string | null;
-}
-
-interface ClubImagesData {
-  images?: ClubImageApiRow[];
-}
+import EventImageUpload from '../components/EventImageUpload';
 
 type StripeTone = 'slate' | 'green' | 'amber' | 'rose';
-
-type ClubImagesResponse = ClubImageApiRow[] | ClubImagesData | null;
 
 type RawStripeStatus = Partial<StripeConnectStatus & {
   connectedAccountId?: string | null;
@@ -56,17 +36,12 @@ interface ApiErrorResponse {
 }
 
 export default function ClubSettingsPage() {
-  const { token } = useAuth();
+  const { token, setClub: persistClub } = useAuth();
   const {
     data: club,
     loading: clubLoading,
     refetch: refetchClub,
   } = useFetch<Club>('/owner/club');
-  const {
-    data: imagesData,
-    loading: imagesLoading,
-    refetch: refetchImages,
-  } = useFetch<ClubImagesResponse>('/owner/club/images');
   const {
     data: stripeStatus,
     loading: stripeLoading,
@@ -75,31 +50,13 @@ export default function ClubSettingsPage() {
 
   const [name, setName] = useState('');
   const [subtitle, setSubtitle] = useState('');
+  const [image, setImage] = useState('');
   const [address, setAddress] = useState('');
   const [phone, setPhone] = useState('');
   const [website, setWebsite] = useState('');
   const [saving, setSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [startingOnboarding, setStartingOnboarding] = useState(false);
-
-  const [newImageUrl, setNewImageUrl] = useState('');
-  const [newImageAlt, setNewImageAlt] = useState('');
-  const [addingImage, setAddingImage] = useState(false);
-  const [showAddImage, setShowAddImage] = useState(false);
-
-  const clubImages = useMemo<ClubImage[]>(() => {
-    const rawImages = Array.isArray(imagesData)
-      ? imagesData
-      : imagesData?.images ?? [];
-
-    return rawImages.map((image) => ({
-      id: image.id,
-      club_id: image.clubId ?? image.club_id ?? '',
-      url: image.url,
-      display_order: image.displayOrder ?? image.display_order ?? 0,
-      alt_text: image.altText ?? image.alt_text ?? undefined,
-    }));
-  }, [imagesData]);
 
   const normalizedStripeStatus = useMemo<StripeConnectStatus>(() => {
     const rawStripeStatus = stripeStatus ?? {};
@@ -129,6 +86,7 @@ export default function ClubSettingsPage() {
 
     setName(club.name ?? '');
     setSubtitle(club.subtitle ?? '');
+    setImage(club.image ?? '');
     setAddress(club.address ?? '');
     setPhone(club.phone_number ?? '');
     setWebsite(club.website ?? '');
@@ -141,10 +99,9 @@ export default function ClubSettingsPage() {
 
     trackEvent('owner_club_settings_viewed', {
       club_id: club.id,
-      image_count: clubImages.length,
       stripe_connected: Boolean(normalizedStripeStatus.connected_account_id),
     });
-  }, [club, clubLoading, clubImages.length, normalizedStripeStatus.connected_account_id]);
+  }, [club, clubLoading, normalizedStripeStatus.connected_account_id]);
 
   const stripeToneClasses: Record<StripeTone, string> = {
     slate: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -209,6 +166,7 @@ export default function ClubSettingsPage() {
         body: JSON.stringify({
           name,
           subtitle,
+          image: image || undefined,
           address: address || undefined,
           phone_number: phone || undefined,
           website: website || undefined,
@@ -219,10 +177,13 @@ export default function ClubSettingsPage() {
         throw new Error('Errore nel salvataggio');
       }
 
+      const updatedClub = (await res.json()) as Club;
+
       trackEvent('owner_club_updated', {
-        club_id: club?.id ?? null,
+        club_id: updatedClub.id,
       });
 
+      persistClub(updatedClub);
       setSaveSuccess(true);
       refetchClub();
       refetchStripeStatus();
@@ -294,95 +255,14 @@ export default function ClubSettingsPage() {
     }
   };
 
-  const handleAddImage = async (e: FormEvent) => {
-    e.preventDefault();
-    setAddingImage(true);
-
-    trackEvent('owner_club_image_add_submitted', {
-      club_id: club?.id ?? null,
-    });
-
-    try {
-      const res = await fetch(`${API_URL}/owner/club/images`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          url: newImageUrl,
-          alt_text: newImageAlt || undefined,
-          display_order: clubImages.length,
-        }),
-      });
-
-      if (!res.ok) {
-        throw new Error('Errore nel caricamento');
-      }
-
-      trackEvent('owner_club_image_added', {
-        club_id: club?.id ?? null,
-      });
-
-      setNewImageUrl('');
-      setNewImageAlt('');
-      setShowAddImage(false);
-      refetchImages();
-    } catch (err) {
-      trackEvent('owner_club_image_add_failed', {
-        club_id: club?.id ?? null,
-        error_message: err instanceof Error ? err.message : 'Errore',
-      });
-      alert(err instanceof Error ? err.message : 'Errore');
-    } finally {
-      setAddingImage(false);
-    }
-  };
-
-  const handleDeleteImage = async (imageId: string) => {
-    if (!confirm('Rimuovere questa immagine?')) {
-      return;
-    }
-
-    try {
-      const res = await fetch(`${API_URL}/owner/club/images/${imageId}`, {
-        method: 'DELETE',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      if (!res.ok) {
-        throw new Error('Errore nella rimozione');
-      }
-
-      trackEvent('owner_club_image_deleted', {
-        club_id: club?.id ?? null,
-        image_id: imageId,
-      });
-      refetchImages();
-    } catch (err) {
-      trackEvent('owner_club_image_delete_failed', {
-        club_id: club?.id ?? null,
-        image_id: imageId,
-        error_message: err instanceof Error ? err.message : 'Errore',
-      });
-      alert(err instanceof Error ? err.message : 'Errore');
-    }
-  };
-
   if (clubLoading) {
     return <div className="text-gray-500">Caricamento...</div>;
   }
 
   return (
     <div className="max-w-4xl">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Impostazioni Locale</h1>
-        <a
-          href="/dashboard/club/tour"
-          className="rounded-lg bg-pink-600 px-4 py-2 text-sm font-medium text-white hover:bg-pink-700"
-        >
-          Configura tour 360°
-        </a>
       </div>
 
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
@@ -473,6 +353,14 @@ export default function ClubSettingsPage() {
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-4">Informazioni e commissioni</h2>
         <form onSubmit={handleSave} className="space-y-5">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Immagine locale</label>
+            <EventImageUpload
+              currentUrl={image || undefined}
+              onUploaded={(url) => setImage(url)}
+            />
+          </div>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Nome</label>
@@ -542,100 +430,6 @@ export default function ClubSettingsPage() {
         </form>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Galleria Immagini</h2>
-          <button
-            onClick={() => setShowAddImage(true)}
-            className="flex items-center gap-2 bg-gray-900 text-white px-4 py-2 rounded-lg text-sm hover:bg-gray-800 transition-colors"
-          >
-            <Plus size={16} />
-            Aggiungi
-          </button>
-        </div>
-
-        {showAddImage && (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div className="bg-white rounded-xl p-6 w-full max-w-md">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-bold text-gray-900">Nuova immagine</h3>
-                <button
-                  onClick={() => setShowAddImage(false)}
-                  className="text-gray-400 hover:text-gray-600"
-                >
-                  <X size={20} />
-                </button>
-              </div>
-              <form onSubmit={handleAddImage} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    URL immagine
-                  </label>
-                  <input
-                    value={newImageUrl}
-                    onChange={e => setNewImageUrl(e.target.value)}
-                    required
-                    placeholder="https://..."
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-gray-900 outline-none text-gray-900"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Descrizione (opzionale)
-                  </label>
-                  <input
-                    value={newImageAlt}
-                    onChange={e => setNewImageAlt(e.target.value)}
-                    placeholder="Sala principale"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-gray-900 outline-none text-gray-900"
-                  />
-                </div>
-                <button
-                  type="submit"
-                  disabled={addingImage}
-                  className="w-full bg-gray-900 text-white py-2.5 rounded-lg font-medium hover:bg-gray-800 disabled:opacity-50"
-                >
-                  {addingImage ? 'Aggiungendo...' : 'Aggiungi'}
-                </button>
-              </form>
-            </div>
-          </div>
-        )}
-
-        {imagesLoading ? (
-          <p className="text-gray-500 text-sm">Caricamento...</p>
-        ) : clubImages.length === 0 ? (
-          <p className="text-gray-500 text-sm">
-            Nessuna immagine. Aggiungi la prima immagine del locale.
-          </p>
-        ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {clubImages.map((img) => (
-              <div
-                key={img.id}
-                className="relative group rounded-lg overflow-hidden aspect-video bg-gray-100"
-              >
-                <img
-                  src={img.url}
-                  alt={img.alt_text ?? ''}
-                  className="w-full h-full object-cover"
-                />
-                <button
-                  onClick={() => handleDeleteImage(img.id)}
-                  className="absolute top-2 right-2 bg-red-600 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
-                >
-                  <Trash2 size={14} />
-                </button>
-                {img.alt_text && (
-                  <div className="absolute bottom-0 left-0 right-0 bg-black/50 text-white text-xs px-2 py-1 truncate">
-                    {img.alt_text}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/pierre_dashboard/src/pages/EventReservationsPage.tsx
+++ b/pierre_dashboard/src/pages/EventReservationsPage.tsx
@@ -15,7 +15,7 @@ import {
 import { useFetch } from '../hooks/useFetch';
 import { useAuth } from '../context/AuthContext';
 import { API_URL } from '../config/api';
-import type { EventReservationStats, TableResponse } from '../types';
+import type { EventReservationStats, EventResponse, TableResponse } from '../types';
 import { trackEvent } from '../config/analytics';
 import { EmptyState, PageHeader, SectionCard } from '../components/ui';
 import { ui } from '../components/ui-classes';
@@ -74,6 +74,18 @@ function getReservationStatusLabel(reservation: OwnerReservation): string {
   return STATUS_LABELS[reservation.status] ?? reservation.status;
 }
 
+function formatEventDate(dateStr: string): string {
+  const isoCandidate = dateStr.includes('T') ? dateStr : dateStr.replace(' ', 'T');
+  const d = new Date(isoCandidate);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  return new Intl.DateTimeFormat('it-IT', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(d);
+}
+
 function getReservationPaymentNote(reservation: OwnerReservation): string | null {
   if (
     reservation.status === 'pending' &&
@@ -95,6 +107,7 @@ export default function EventReservationsPage() {
   );
   const { data: tablesData } = useFetch<TablesData>(`/owner/events/${eventId}/tables`);
   const { data: statsData } = useFetch<EventReservationStats>(`/owner/events/${eventId}/stats`);
+  const { data: eventData } = useFetch<EventResponse>(`/events/${eventId}`);
 
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState<string>('all');
@@ -368,8 +381,12 @@ export default function EventReservationsPage() {
         </Link>
         <PageHeader
           className="mb-0"
-          title="Prenotazioni"
-          description="Gestisci stato, area/tavolo e composizione delle prenotazioni della serata."
+          title={eventData ? `Prenotazioni · ${eventData.title}` : 'Prenotazioni'}
+          description={
+            eventData
+              ? `${formatEventDate(eventData.date)}${eventData.time ? ` · ${eventData.time}` : ''}${eventData.venue ? ` · ${eventData.venue}` : ''}`
+              : 'Gestisci stato, area/tavolo e composizione delle prenotazioni della serata.'
+          }
           action={
             <button onClick={() => setShowForm(true)} className={ui.primaryButton}>
               <Plus size={18} />

--- a/pierre_dashboard/src/pages/EventsPage.tsx
+++ b/pierre_dashboard/src/pages/EventsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type FormEvent } from "react";
-import { Link } from "react-router-dom";
-import { Plus, ChevronRight, X, Pencil, Trash2 } from "lucide-react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Plus, ChevronRight, X, Pencil, Trash2, Compass } from "lucide-react";
 import { useFetch } from "../hooks/useFetch";
 import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../config/api";
@@ -97,7 +97,15 @@ const emptyForm: EventFormData = {
 };
 
 export default function EventsPage() {
-  const [filterDate, setFilterDate] = useState(todayStr());
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filterDate = searchParams.get("from") ?? todayStr();
+  const setFilterDate = (value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set("from", value);
+    else next.delete("from");
+    setSearchParams(next, { replace: true });
+  };
   const { data: events, loading, refetch } = useFetch<EventResponse[]>(`/owner/events?from_date=${filterDate}`);
   const { data: genres } = useFetch<Genre[]>("/genres");
   const { token } = useAuth();
@@ -249,28 +257,25 @@ export default function EventsPage() {
         title="Eventi"
         description="Crea, modifica e monitora le serate in programma mantenendo locandine, prezzi e dettagli coerenti."
         action={
-          <button onClick={openCreate} className={ui.primaryButton}>
-            <Plus size={18} />
-            Nuovo evento
-          </button>
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              value={filterDate}
+              onChange={(e) => setFilterDate(e.target.value)}
+              aria-label="Filtra eventi da data"
+              className={`${ui.input} h-10 w-37.5 py-1 text-sm`}
+            />
+            <button onClick={openCreate} className={`${ui.primaryButton} whitespace-nowrap`}>
+              <Plus size={18} />
+              Nuovo evento
+            </button>
+          </div>
         }
       />
 
-      {/* Date filter */}
-      <SectionCard className="mb-6 p-4">
-      <div className="flex flex-wrap items-center gap-3">
-        <label className={ui.label}>Da data</label>
-        <input
-          type="date"
-          value={filterDate}
-          onChange={(e) => setFilterDate(e.target.value)}
-          className={`${ui.input} w-auto`}
-        />
-        <span className={`${ui.helperText} ${ui.tabularNums}`}>
-          {filteredEvents.length} eventi
-        </span>
-      </div>
-      </SectionCard>
+      <p className={`mb-4 ${ui.helperText} ${ui.tabularNums}`}>
+        {filteredEvents.length} eventi
+      </p>
 
       {/* Create / Edit modal */}
       {showForm && (
@@ -544,6 +549,16 @@ export default function EventsPage() {
                   </div>
                 </Link>
                 <div className="flex justify-end gap-2 border-t border-gray-100 px-4 pb-3 pt-2">
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      navigate(`/dashboard/events/${event.id}/tour`);
+                    }}
+                    className="inline-flex min-h-8 items-center gap-1 rounded-lg px-2 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+                  >
+                    <Compass size={13} /> Tour 360
+                  </button>
                   <button
                     onClick={(e) => openEdit(e, event)}
                     className="inline-flex min-h-8 items-center gap-1 rounded-lg px-2 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"

--- a/rust_BE/src/controllers/club_owner_controller.rs
+++ b/rust_BE/src/controllers/club_owner_controller.rs
@@ -395,11 +395,19 @@ pub async fn get_my_club_tables(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    let tables = table_persistence::get_tables_by_event_id(&state.db_pool, event_uuid)
+    let event_tables = table_persistence::get_tables_by_event_id(&state.db_pool, event_uuid)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let table_responses: Vec<TableResponse> = tables.into_iter().map(|t| t.into()).collect();
+    let club_tables = table_persistence::get_tables_by_club_id(&state.db_pool, club.id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let table_responses: Vec<TableResponse> = event_tables
+        .into_iter()
+        .chain(club_tables.into_iter())
+        .map(|t| t.into())
+        .collect();
     Ok(Json(TablesResponse {
         tables: table_responses,
     }))
@@ -482,7 +490,7 @@ pub async fn update_my_club(
     let update_req = UpdateClubRequest {
         name: payload.name,
         subtitle: payload.subtitle,
-        image: None,
+        image: payload.image,
         address: payload.address,
         phone_number: payload.phone_number,
         website: payload.website,

--- a/rust_BE/src/models/club.rs
+++ b/rust_BE/src/models/club.rs
@@ -67,6 +67,12 @@ pub struct ClubResponse {
     pub subtitle: String,
     pub image: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone_number: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub website: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stripe_connected_account_id: Option<String>,
@@ -92,6 +98,9 @@ impl From<Club> for ClubResponse {
             name: club.name,
             subtitle: club.subtitle.unwrap_or_default(),
             image: club.image,
+            address: club.address,
+            phone_number: club.phone_number,
+            website: club.website,
             owner_id: club.owner_id.map(|id| id.to_string()),
             stripe_connected_account_id: club.stripe_connected_account_id,
             stripe_onboarding_complete: club.stripe_onboarding_complete,

--- a/rust_BE/src/models/club_owner.rs
+++ b/rust_BE/src/models/club_owner.rs
@@ -71,6 +71,7 @@ pub struct ClubOwnerAuthResponse {
 pub struct OwnerUpdateClubRequest {
     pub name: Option<String>,
     pub subtitle: Option<String>,
+    pub image: Option<String>,
     pub address: Option<String>,
     pub phone_number: Option<String>,
     pub website: Option<String>,


### PR DESCRIPTION
## Summary
- Round of UX/data-flow fixes on the club-owner dashboard:
  - Sidebar active-state fix (no more dual-highlight) + new "Tour 360° locale" nav entry
  - EventsPage: inline date filter persisted in querystring, Tour 360 button per event
  - EventReservationsPage: header shows event title + date
  - Manual reservation modal: now lists club-level tables (was empty after the club-level migration)
  - ClubSettingsPage: image upload for the club, AuthContext refreshed on save, gallery hidden
- Two underlying backend issues fixed:
  - `ClubResponse` was missing `address`/`phone_number`/`website` — they were saved in DB but never returned, making the form reload empty
  - `update_my_club` hardcoded `image: None`, so the new image field couldn't be persisted
- `AuthContext` now exposes `setClub`/`setOwner` that update both state and `localStorage`, keeping the cached profile and sidebar in sync after edits

See [docs/daily-progress/2026-05-06-dashboard-bugfixes.md](docs/daily-progress/2026-05-06-dashboard-bugfixes.md) for full details.

## Test plan
- [x] Login as club owner, navigate to "Aree e tavoli" → only that nav entry is highlighted (not "Impostazioni Locale")
- [x] EventsPage: change date filter, reload → filter persists via `?from=...`; filter sits next to "Nuovo evento" on the same row
- [x] EventsPage: click "Tour 360" on a card → goes to `/dashboard/events/:id/tour`; font matches the other two buttons
- [x] Open an event's reservations page → header shows `Prenotazioni · {title}` with date/time/venue underneath
- [x] Open "Prenotazione manuale" modal → tables created in "Aree e tavoli" appear in the dropdown
- [x] Sidebar "Tour 360° locale" → routes to `/dashboard/club/tour`
- [ ] Impostazioni Locale: edit name/address/phone/website + upload a new club image → save → reload → values persist; sidebar club name/image update without re-login
- [ ] `cargo check` ✅, `tsc --noEmit` ✅