### PR TITLE
Add daily garbage collector background job for DB and storage cleanup

### DIFF
--- a/docs/daily-progress/2026-05-07-garbage-collector-job.md
+++ b/docs/daily-progress/2026-05-07-garbage-collector-job.md
@@ -1,0 +1,153 @@
+# 2026-05-07: Garbage Collector Background Job
+
+**Branch**: `claude/fix-pr-root-issue-44-Pkakb`
+**Issue**: [#44](https://github.com/pierre-clubs/PR-root/issues/44)
+**Status**: Ready for review
+
+---
+
+## Overview
+
+Added a daily background job that detects and removes orphan rows from the
+DB and orphan objects from Supabase Storage. The job follows the existing
+`jobs/<name>.rs` + `record_job_run()` pattern (same shape as
+`idempotency_cleanup` and `outbox_dispatcher`), is gated by `GC_ENABLED`,
+defaults to `GC_DRY_RUN=true`, and isolates each cleaner so a failure in one
+does not stop the others.
+
+---
+
+## Context
+
+The DB and storage buckets accumulate orphans because some FK relationships
+aren't strict enough:
+
+- `events.club_id` is `FK -> clubs.id ON DELETE SET NULL`, so deleting a
+  club leaves orphan events with `club_id IS NULL` (issue #43).
+- `payments` has no FK to anything — only linked indirectly via
+  `reservation_payment_shares.payment_id`.
+- Storage objects in `event-images` (and the `panoramas` bucket when
+  configured) are never deleted when the referencing row goes away or when
+  an upload is abandoned mid-flow.
+
+Other entity FKs (`tickets / tables / table_reservations /
+reservation_payment_shares / reservation_guests / table_images`) already
+cascade in current migrations, so cleaners for those are shipped as
+**safety nets** that should normally find zero rows.
+
+The user-confirmed scope decisions:
+
+- **Panoramas bucket**: cleaner is gated by `SUPABASE_PANORAMAS_BUCKET`.
+  When unset, the panoramas cleaner is reported as `skipped` in the round
+  details.
+- **Idempotency keys**: existing `jobs/idempotency_cleanup.rs` (hourly)
+  stays untouched; not subsumed by the GC.
+- **Tests**: logic-only unit tests for the storage helpers; DB-backed
+  per-cleaner tests are deferred to a follow-up PR. Validation comes from
+  staging dry-run.
+
+---
+
+## Changes
+
+### Backend
+
+#### New module `services/garbage_collector/`
+- `mod.rs` — `CleanerStats { detected, deleted }` and `CleanerCtx
+  { dry_run, min_orphan_age_hours }` plus per-cleaner sub-modules.
+- `events_orphans.rs` — deletes events with `club_id IS NULL`.
+- `payments_orphans.rs` — deletes payments not referenced by any
+  `reservation_payment_shares.payment_id`.
+- `tickets_orphans.rs`, `tables_orphans.rs`, `reservations_orphans.rs`,
+  `reservation_shares_orphans.rs`, `reservation_guests_orphans.rs`,
+  `table_images_orphans.rs` — safety-net cleaners for tables that already
+  have `ON DELETE CASCADE`. Each deletes rows whose parent row no longer
+  exists.
+- `storage.rs` — `run_event_images` and `run_panoramas`. Builds the set of
+  referenced storage paths from the DB (`events.image`, `table_images.url`,
+  `events.marzipano_config[].imageUrl`), lists the bucket recursively via
+  Supabase Storage REST API, marks unreferenced objects older than
+  `min_orphan_age_hours` as orphans, and batch-deletes them in chunks of 100.
+  Pure helpers (`reference_path_from_url`, `extract_panorama_urls`,
+  `diff_orphans`, `chunk_for_delete`) covered by 9 unit tests.
+
+Every DB cleaner runs the count + delete inside a single `BEGIN…COMMIT`
+transaction, with `ROLLBACK` in dry-run mode so the row count is observed
+without persisting the delete.
+
+#### New job `jobs/garbage_collector.rs`
+Orchestrator with `pub async fn run(state: Arc<AppState>)` — sleeps for
+`GC_FIRST_RUN_DELAY_SECONDS` then loops on `tokio::time::interval` of
+`GC_INTERVAL_SECONDS`. Each round invokes every cleaner, captures per-cleaner
+errors, aggregates totals, logs `"GC round completed"` with structured
+fields, and writes one row to `background_job_runs` with status
+`success | partial_failure | failure` and a `cleaners` JSON map.
+
+#### Wiring
+- `services/mod.rs` — `pub mod garbage_collector;`.
+- `jobs/mod.rs` — `pub mod garbage_collector;` and conditional spawn gated
+  on `app_state.config.gc.enabled`. Logs "Garbage collector disabled
+  (GC_ENABLED=false)" when off.
+- `bootstrap/config.rs` — new `GcConfig` struct on `AppConfig` with env
+  vars: `GC_ENABLED` (default `false`), `GC_DRY_RUN` (default `true`),
+  `GC_INTERVAL_SECONDS` (default `86400`), `GC_MIN_ORPHAN_AGE_HOURS`
+  (default `24`), `GC_FIRST_RUN_DELAY_SECONDS` (default `300`),
+  `SUPABASE_PANORAMAS_BUCKET` (optional).
+
+### Database
+
+No schema changes. `background_job_runs` already exists and is the audit
+sink, used the same way as the other jobs.
+
+---
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `rust_BE/src/services/garbage_collector/mod.rs` | NEW: shared types + sub-module declarations |
+| `rust_BE/src/services/garbage_collector/events_orphans.rs` | NEW: real orphan cleaner (`club_id IS NULL`) |
+| `rust_BE/src/services/garbage_collector/payments_orphans.rs` | NEW: real orphan cleaner (no share refs) |
+| `rust_BE/src/services/garbage_collector/tickets_orphans.rs` | NEW: safety-net cleaner |
+| `rust_BE/src/services/garbage_collector/tables_orphans.rs` | NEW: safety-net cleaner |
+| `rust_BE/src/services/garbage_collector/reservations_orphans.rs` | NEW: safety-net cleaner |
+| `rust_BE/src/services/garbage_collector/reservation_shares_orphans.rs` | NEW: safety-net cleaner |
+| `rust_BE/src/services/garbage_collector/reservation_guests_orphans.rs` | NEW: safety-net cleaner |
+| `rust_BE/src/services/garbage_collector/table_images_orphans.rs` | NEW: safety-net cleaner |
+| `rust_BE/src/services/garbage_collector/storage.rs` | NEW: bucket cleaners + 9 unit tests |
+| `rust_BE/src/jobs/garbage_collector.rs` | NEW: round orchestrator + record_job_run |
+| `rust_BE/src/services/mod.rs` | Register `garbage_collector` module |
+| `rust_BE/src/jobs/mod.rs` | Register module + conditional spawn |
+| `rust_BE/src/bootstrap/config.rs` | Add `GcConfig` and parse env vars |
+
+---
+
+## Verification
+
+- `cargo check` — clean (only pre-existing warnings).
+- `cargo clippy --bin rust_BE` — no new findings on GC code.
+- `cargo test --bin rust_BE garbage_collector` — 9/9 tests pass.
+
+Recommended staging procedure:
+
+1. Deploy with `GC_ENABLED=true GC_DRY_RUN=true`.
+2. Wait one tick (default 24 h, or set `GC_INTERVAL_SECONDS=10`
+   `GC_FIRST_RUN_DELAY_SECONDS=0` for a quick smoke).
+3. Inspect `SELECT details FROM background_job_runs WHERE
+   job_name='garbage_collector' ORDER BY created_at DESC LIMIT 5;` and
+   compare per-cleaner `detected` counts against a manual SQL audit.
+4. Flip `GC_DRY_RUN=false` and confirm `deleted == detected` from the prior
+   dry-run.
+
+---
+
+## Follow-up (out of scope)
+
+- Add formal `ON DELETE CASCADE` FKs on `events.club_id` (currently `SET
+  NULL`) once the product implications are decided. The GC would then act
+  purely as a safety net.
+- DB-backed `sqlx::test` infrastructure with a per-cleaner test that seeds
+  an orphan and asserts it's detected/deleted. Deferred per scoping
+  decision; logic tests cover the storage helpers today.
+- Decide whether `jobs/idempotency_cleanup.rs` should be folded into the GC
+  to consolidate background scheduling.

--- a/rust_BE/src/bootstrap/config.rs
+++ b/rust_BE/src/bootstrap/config.rs
@@ -61,6 +61,16 @@ pub struct StorageConfig {
 }
 
 #[derive(Clone, Debug)]
+pub struct GcConfig {
+    pub enabled: bool,
+    pub dry_run: bool,
+    pub interval_seconds: u64,
+    pub min_orphan_age_hours: i64,
+    pub first_run_delay_seconds: u64,
+    pub panoramas_bucket: Option<String>,
+}
+
+#[derive(Clone, Debug)]
 pub struct AppConfig {
     pub database: DatabaseConfig,
     pub auth: AuthConfig,
@@ -70,6 +80,7 @@ pub struct AppConfig {
     pub feature_flags: FeatureFlagsConfig,
     pub jobs: JobsConfig,
     pub storage: StorageConfig,
+    pub gc: GcConfig,
     pub app_base_url: String,
     pub owner_app_base_url: String,
     pub auto_run_db_migrations: bool,
@@ -195,6 +206,30 @@ impl AppConfig {
         let event_images_bucket =
             env::var("SUPABASE_EVENT_IMAGES_BUCKET").unwrap_or_else(|_| "event-images".to_string());
 
+        let gc_enabled = env::var("GC_ENABLED")
+            .ok()
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(false);
+        let gc_dry_run = env::var("GC_DRY_RUN")
+            .ok()
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(true);
+        let gc_interval_seconds = env::var("GC_INTERVAL_SECONDS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(86_400);
+        let gc_min_orphan_age_hours = env::var("GC_MIN_ORPHAN_AGE_HOURS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(24);
+        let gc_first_run_delay_seconds = env::var("GC_FIRST_RUN_DELAY_SECONDS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(300);
+        let gc_panoramas_bucket = env::var("SUPABASE_PANORAMAS_BUCKET")
+            .ok()
+            .filter(|s| !s.is_empty());
+
         Self {
             database: DatabaseConfig {
                 url: database_url,
@@ -237,6 +272,14 @@ impl AppConfig {
                 supabase_url,
                 service_role_key: supabase_service_role_key,
                 event_images_bucket,
+            },
+            gc: GcConfig {
+                enabled: gc_enabled,
+                dry_run: gc_dry_run,
+                interval_seconds: gc_interval_seconds,
+                min_orphan_age_hours: gc_min_orphan_age_hours,
+                first_run_delay_seconds: gc_first_run_delay_seconds,
+                panoramas_bucket: gc_panoramas_bucket,
             },
             app_base_url,
             owner_app_base_url,

--- a/rust_BE/src/jobs/garbage_collector.rs
+++ b/rust_BE/src/jobs/garbage_collector.rs
@@ -1,0 +1,248 @@
+//! Daily garbage collection orchestrator.
+//!
+//! Runs each cleaner in `services::garbage_collector` and records one
+//! `background_job_runs` row per round with per-cleaner counts. A failure in
+//! one cleaner does not stop the others.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Map, Value};
+use tracing::{error, info};
+
+use crate::bootstrap::state::AppState;
+use crate::services::garbage_collector::{
+    events_orphans, payments_orphans, reservation_guests_orphans, reservation_shares_orphans,
+    reservations_orphans, storage, table_images_orphans, tables_orphans, tickets_orphans,
+    CleanerCtx, CleanerStats,
+};
+
+pub async fn run(state: Arc<AppState>) {
+    let cfg = &state.config.gc;
+    let first_delay = Duration::from_secs(cfg.first_run_delay_seconds);
+    if !first_delay.is_zero() {
+        tokio::time::sleep(first_delay).await;
+    }
+    let mut interval = tokio::time::interval(Duration::from_secs(cfg.interval_seconds));
+    // First tick fires immediately after the initial sleep; subsequent ticks
+    // are spaced by `interval_seconds`.
+    loop {
+        interval.tick().await;
+        run_round(&state).await;
+    }
+}
+
+async fn run_round(state: &AppState) {
+    let cfg = &state.config.gc;
+    let ctx = CleanerCtx {
+        dry_run: cfg.dry_run,
+        min_orphan_age_hours: cfg.min_orphan_age_hours,
+    };
+
+    let mut details: Map<String, Value> = Map::new();
+    let mut total_detected: u64 = 0;
+    let mut total_deleted: u64 = 0;
+    let mut succeeded: u32 = 0;
+    let mut failed: Vec<String> = Vec::new();
+
+    record_db(
+        "events_orphans",
+        events_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "payments_orphans",
+        payments_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "tickets_orphans",
+        tickets_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "tables_orphans",
+        tables_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "reservations_orphans",
+        reservations_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "reservation_shares_orphans",
+        reservation_shares_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "reservation_guests_orphans",
+        reservation_guests_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+    record_db(
+        "table_images_orphans",
+        table_images_orphans::run(&state.db_pool, ctx).await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+
+    record_storage(
+        "storage_event_images",
+        storage::run_event_images(
+            &state.db_pool,
+            &state.http_client,
+            &state.config.storage,
+            ctx,
+        )
+        .await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+
+    if let Some(bucket) = state.config.gc.panoramas_bucket.as_deref() {
+        record_storage(
+            "storage_panoramas",
+            storage::run_panoramas(
+                &state.db_pool,
+                &state.http_client,
+                &state.config.storage,
+                bucket,
+                ctx,
+            )
+            .await,
+            &mut details,
+            &mut total_detected,
+            &mut total_deleted,
+            &mut succeeded,
+            &mut failed,
+        );
+    } else {
+        details.insert("storage_panoramas".into(), json!({ "skipped": true }));
+    }
+
+    let status = if failed.is_empty() {
+        "success"
+    } else if succeeded == 0 {
+        "failure"
+    } else {
+        "partial_failure"
+    };
+
+    info!(
+        log_category = "gc",
+        dry_run = ctx.dry_run,
+        total_detected,
+        total_deleted,
+        failed_cleaners = ?failed,
+        "GC round completed"
+    );
+
+    let error_summary = if failed.is_empty() {
+        None
+    } else {
+        Some(format!("failed cleaners: {}", failed.join(", ")))
+    };
+    crate::jobs::record_job_run(
+        state,
+        "garbage_collector",
+        status,
+        json!({
+            "dry_run": ctx.dry_run,
+            "min_orphan_age_hours": ctx.min_orphan_age_hours,
+            "total_detected": total_detected,
+            "total_deleted": total_deleted,
+            "cleaners": Value::Object(details),
+        }),
+        error_summary.as_deref(),
+    )
+    .await;
+}
+
+fn record_db(
+    name: &str,
+    result: Result<CleanerStats, sqlx::Error>,
+    details: &mut Map<String, Value>,
+    total_detected: &mut u64,
+    total_deleted: &mut u64,
+    succeeded: &mut u32,
+    failed: &mut Vec<String>,
+) {
+    match result {
+        Ok(stats) => {
+            *total_detected += stats.detected;
+            *total_deleted += stats.deleted;
+            *succeeded += 1;
+            details.insert(
+                name.into(),
+                json!({ "detected": stats.detected, "deleted": stats.deleted }),
+            );
+        }
+        Err(e) => {
+            error!(cleaner = name, error = %e, log_category = "gc", "GC cleaner failed");
+            failed.push(name.into());
+            details.insert(name.into(), json!({ "error": e.to_string() }));
+        }
+    }
+}
+
+fn record_storage(
+    name: &str,
+    result: Result<CleanerStats, String>,
+    details: &mut Map<String, Value>,
+    total_detected: &mut u64,
+    total_deleted: &mut u64,
+    succeeded: &mut u32,
+    failed: &mut Vec<String>,
+) {
+    match result {
+        Ok(stats) => {
+            *total_detected += stats.detected;
+            *total_deleted += stats.deleted;
+            *succeeded += 1;
+            details.insert(
+                name.into(),
+                json!({ "detected": stats.detected, "deleted": stats.deleted }),
+            );
+        }
+        Err(e) => {
+            error!(cleaner = name, error = %e, log_category = "gc", "GC cleaner failed");
+            failed.push(name.into());
+            details.insert(name.into(), json!({ "error": e }));
+        }
+    }
+}

--- a/rust_BE/src/jobs/mod.rs
+++ b/rust_BE/src/jobs/mod.rs
@@ -5,6 +5,7 @@ use tracing::{error, info};
 
 use crate::bootstrap::state::AppState;
 
+pub mod garbage_collector;
 pub mod idempotency_cleanup;
 pub mod outbox_dispatcher;
 pub mod payment_maintenance;
@@ -27,6 +28,18 @@ pub fn start_background_jobs(app_state: Arc<AppState>) {
         outbox_dispatcher::run(outbox_state).await;
     });
     info!("Outbox dispatcher job started");
+
+    if app_state.config.gc.enabled {
+        let gc_state = Arc::clone(&app_state);
+        let dry_run = app_state.config.gc.dry_run;
+        let interval_seconds = app_state.config.gc.interval_seconds;
+        tokio::spawn(async move {
+            garbage_collector::run(gc_state).await;
+        });
+        info!(dry_run, interval_seconds, "Garbage collector job started");
+    } else {
+        info!("Garbage collector disabled (GC_ENABLED=false)");
+    }
 }
 
 pub async fn record_job_run(

--- a/rust_BE/src/services/garbage_collector/events_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/events_orphans.rs
@@ -1,0 +1,58 @@
+//! Cleans events whose `club_id` is NULL — typically left behind when a club
+//! is deleted (FK is `ON DELETE SET NULL`). This is a real orphan source.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM events
+        WHERE club_id IS NULL
+          AND created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM events
+            WHERE club_id IS NULL
+              AND created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "events_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/mod.rs
+++ b/rust_BE/src/services/garbage_collector/mod.rs
@@ -1,0 +1,30 @@
+//! Garbage collection cleaners.
+//!
+//! Each cleaner is a self-contained function that detects and removes one
+//! class of orphan rows or storage objects. Cleaners are invoked by
+//! `jobs::garbage_collector` and isolated from each other so a failure in one
+//! does not stop the others.
+
+use serde::Serialize;
+
+#[derive(Debug, Default, Clone, Copy, Serialize)]
+pub struct CleanerStats {
+    pub detected: u64,
+    pub deleted: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CleanerCtx {
+    pub dry_run: bool,
+    pub min_orphan_age_hours: i64,
+}
+
+pub mod events_orphans;
+pub mod payments_orphans;
+pub mod reservation_guests_orphans;
+pub mod reservation_shares_orphans;
+pub mod reservations_orphans;
+pub mod storage;
+pub mod table_images_orphans;
+pub mod tables_orphans;
+pub mod tickets_orphans;

--- a/rust_BE/src/services/garbage_collector/payments_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/payments_orphans.rs
@@ -1,0 +1,62 @@
+//! Cleans `payments` rows that no `reservation_payment_shares` references.
+//! `payments` has no formal FK; this is a real orphan source.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM payments p
+        WHERE NOT EXISTS (
+            SELECT 1 FROM reservation_payment_shares s WHERE s.payment_id = p.id
+        )
+        AND p.insert_date < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM payments p
+            WHERE NOT EXISTS (
+                SELECT 1 FROM reservation_payment_shares s WHERE s.payment_id = p.id
+            )
+            AND p.insert_date < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "payments_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/reservation_guests_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/reservation_guests_orphans.rs
@@ -1,0 +1,62 @@
+//! Safety-net cleaner: reservation_guests whose reservation no longer exists.
+//! `reservation_id` already has `ON DELETE CASCADE`.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM reservation_guests g
+        WHERE NOT EXISTS (
+            SELECT 1 FROM table_reservations r WHERE r.id = g.reservation_id
+        )
+        AND g.created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM reservation_guests g
+            WHERE NOT EXISTS (
+                SELECT 1 FROM table_reservations r WHERE r.id = g.reservation_id
+            )
+            AND g.created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "reservation_guests_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/reservation_shares_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/reservation_shares_orphans.rs
@@ -1,0 +1,62 @@
+//! Safety-net cleaner: reservation_payment_shares whose reservation no longer exists.
+//! `reservation_id` already has `ON DELETE CASCADE`.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM reservation_payment_shares s
+        WHERE NOT EXISTS (
+            SELECT 1 FROM table_reservations r WHERE r.id = s.reservation_id
+        )
+        AND s.created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM reservation_payment_shares s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM table_reservations r WHERE r.id = s.reservation_id
+            )
+            AND s.created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "reservation_shares_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/reservations_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/reservations_orphans.rs
@@ -1,0 +1,64 @@
+//! Safety-net cleaner: table reservations whose event or table no longer exists.
+//! Both FKs already have `ON DELETE CASCADE`.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM table_reservations r
+        WHERE (
+            NOT EXISTS (SELECT 1 FROM events e WHERE e.id = r.event_id)
+            OR NOT EXISTS (SELECT 1 FROM tables t WHERE t.id = r.table_id)
+        )
+        AND r.created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM table_reservations r
+            WHERE (
+                NOT EXISTS (SELECT 1 FROM events e WHERE e.id = r.event_id)
+                OR NOT EXISTS (SELECT 1 FROM tables t WHERE t.id = r.table_id)
+            )
+            AND r.created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "reservations_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/storage.rs
+++ b/rust_BE/src/services/garbage_collector/storage.rs
@@ -1,0 +1,450 @@
+//! Storage bucket cleaners for Supabase.
+//!
+//! Algorithm (shared by both buckets):
+//! 1. Build the set of referenced storage paths from the DB.
+//! 2. List the bucket recursively via Supabase Storage REST API.
+//! 3. Mark as orphans the listed objects whose path is not referenced and
+//!    whose `created_at` is older than `min_orphan_age_hours`.
+//! 4. In dry-run mode, stop. Otherwise batch-delete the orphans.
+//!
+//! Helpers below (URL parsing, scene extraction, set diff, chunking) are
+//! pure functions covered by unit tests at the bottom of this file.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+use crate::bootstrap::config::StorageConfig;
+
+const DELETE_BATCH_SIZE: usize = 100;
+const LIST_PAGE_SIZE: i64 = 1000;
+
+#[derive(Debug, Deserialize)]
+struct ListedObject {
+    name: String,
+    /// `id` is null for "folder" entries.
+    id: Option<String>,
+    created_at: Option<String>,
+}
+
+pub async fn run_event_images(
+    pool: &PgPool,
+    http: &reqwest::Client,
+    storage: &StorageConfig,
+    ctx: CleanerCtx,
+) -> Result<CleanerStats, String> {
+    let (supabase_url, service_key) = require_storage(storage)?;
+    let bucket = storage.event_images_bucket.as_str();
+
+    let referenced = referenced_event_image_paths(pool, supabase_url, bucket).await?;
+
+    run_bucket(
+        http,
+        supabase_url,
+        service_key,
+        bucket,
+        "storage_event_images",
+        &referenced,
+        ctx,
+    )
+    .await
+}
+
+pub async fn run_panoramas(
+    pool: &PgPool,
+    http: &reqwest::Client,
+    storage: &StorageConfig,
+    bucket: &str,
+    ctx: CleanerCtx,
+) -> Result<CleanerStats, String> {
+    let (supabase_url, service_key) = require_storage(storage)?;
+
+    let referenced = referenced_panorama_paths(pool, supabase_url, bucket).await?;
+
+    run_bucket(
+        http,
+        supabase_url,
+        service_key,
+        bucket,
+        "storage_panoramas",
+        &referenced,
+        ctx,
+    )
+    .await
+}
+
+fn require_storage(storage: &StorageConfig) -> Result<(&str, &str), String> {
+    match (
+        storage.supabase_url.as_deref(),
+        storage.service_role_key.as_deref(),
+    ) {
+        (Some(url), Some(key)) => Ok((url, key)),
+        _ => Err("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set for storage GC".into()),
+    }
+}
+
+async fn run_bucket(
+    http: &reqwest::Client,
+    supabase_url: &str,
+    service_key: &str,
+    bucket: &str,
+    cleaner_name: &'static str,
+    referenced: &HashSet<String>,
+    ctx: CleanerCtx,
+) -> Result<CleanerStats, String> {
+    let listed = list_bucket_recursive(http, supabase_url, service_key, bucket).await?;
+    let now = Utc::now();
+    let min_age = Duration::hours(ctx.min_orphan_age_hours);
+    let candidates = diff_orphans(&listed, referenced, min_age, now);
+    let detected = candidates.len() as u64;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        let mut total = 0u64;
+        for chunk in chunk_for_delete(&candidates, DELETE_BATCH_SIZE) {
+            total += delete_objects(http, supabase_url, service_key, bucket, chunk).await?;
+        }
+        total
+    };
+
+    tracing::info!(
+        cleaner = cleaner_name,
+        bucket,
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats { detected, deleted })
+}
+
+async fn referenced_event_image_paths(
+    pool: &PgPool,
+    supabase_url: &str,
+    bucket: &str,
+) -> Result<HashSet<String>, String> {
+    let event_rows: Vec<(Option<String>,)> =
+        sqlx::query_as("SELECT image FROM events WHERE image IS NOT NULL AND image <> ''")
+            .fetch_all(pool)
+            .await
+            .map_err(|e| format!("failed to load event images: {e}"))?;
+
+    let table_rows: Vec<(String,)> =
+        sqlx::query_as("SELECT url FROM table_images WHERE url IS NOT NULL AND url <> ''")
+            .fetch_all(pool)
+            .await
+            .map_err(|e| format!("failed to load table images: {e}"))?;
+
+    let mut set = HashSet::new();
+    for (url,) in event_rows.into_iter().filter_map(|(u,)| u.map(|u| (u,))) {
+        if let Some(p) = reference_path_from_url(&url, supabase_url, bucket) {
+            set.insert(p);
+        }
+    }
+    for (url,) in table_rows {
+        if let Some(p) = reference_path_from_url(&url, supabase_url, bucket) {
+            set.insert(p);
+        }
+    }
+    Ok(set)
+}
+
+async fn referenced_panorama_paths(
+    pool: &PgPool,
+    supabase_url: &str,
+    bucket: &str,
+) -> Result<HashSet<String>, String> {
+    let rows: Vec<(Option<Value>,)> =
+        sqlx::query_as("SELECT marzipano_config FROM events WHERE marzipano_config IS NOT NULL")
+            .fetch_all(pool)
+            .await
+            .map_err(|e| format!("failed to load marzipano configs: {e}"))?;
+
+    let mut set = HashSet::new();
+    for (cfg,) in rows {
+        if let Some(cfg) = cfg {
+            for url in extract_panorama_urls(&cfg) {
+                if let Some(p) = reference_path_from_url(&url, supabase_url, bucket) {
+                    set.insert(p);
+                }
+            }
+        }
+    }
+    Ok(set)
+}
+
+async fn list_bucket_recursive(
+    http: &reqwest::Client,
+    supabase_url: &str,
+    service_key: &str,
+    bucket: &str,
+) -> Result<Vec<(String, Option<DateTime<Utc>>)>, String> {
+    let mut out: Vec<(String, Option<DateTime<Utc>>)> = Vec::new();
+    let mut prefixes: Vec<String> = vec![String::new()];
+
+    while let Some(prefix) = prefixes.pop() {
+        let mut offset = 0i64;
+        loop {
+            let body = json!({
+                "prefix": prefix,
+                "limit": LIST_PAGE_SIZE,
+                "offset": offset,
+            });
+            let url = format!("{supabase_url}/storage/v1/object/list/{bucket}");
+            let resp = http
+                .post(&url)
+                .header("Authorization", format!("Bearer {service_key}"))
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| format!("list request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(format!("list returned HTTP {status}: {text}"));
+            }
+            let items: Vec<ListedObject> = resp
+                .json()
+                .await
+                .map_err(|e| format!("list json decode failed: {e}"))?;
+            let count = items.len() as i64;
+            for item in items {
+                let full = if prefix.is_empty() {
+                    item.name.clone()
+                } else {
+                    format!("{prefix}/{}", item.name)
+                };
+                if item.id.is_none() {
+                    // folder — recurse
+                    prefixes.push(full);
+                } else {
+                    let created = item.created_at.as_deref().and_then(parse_rfc3339);
+                    out.push((full, created));
+                }
+            }
+            if count < LIST_PAGE_SIZE {
+                break;
+            }
+            offset += count;
+        }
+    }
+    Ok(out)
+}
+
+async fn delete_objects(
+    http: &reqwest::Client,
+    supabase_url: &str,
+    service_key: &str,
+    bucket: &str,
+    paths: &[String],
+) -> Result<u64, String> {
+    if paths.is_empty() {
+        return Ok(0);
+    }
+    let url = format!("{supabase_url}/storage/v1/object/{bucket}");
+    let body = json!({ "prefixes": paths });
+    let resp = http
+        .delete(&url)
+        .header("Authorization", format!("Bearer {service_key}"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("delete request failed: {e}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("delete returned HTTP {status}: {text}"));
+    }
+    Ok(paths.len() as u64)
+}
+
+// --- pure helpers (unit-tested below) ---
+
+/// Strip the Supabase public-URL prefix and return the bucket-relative path.
+/// Returns `None` if the URL is not a Supabase URL for this bucket, or if it
+/// does not look like a Supabase storage URL (in which case the value lives
+/// somewhere else and should not be considered a referenced bucket object).
+fn reference_path_from_url(url: &str, supabase_url: &str, bucket: &str) -> Option<String> {
+    let base = supabase_url.trim_end_matches('/');
+    let public_prefix = format!("{base}/storage/v1/object/public/{bucket}/");
+    let signed_prefix = format!("{base}/storage/v1/object/sign/{bucket}/");
+    let raw_prefix = format!("{base}/storage/v1/object/{bucket}/");
+    let trimmed = url.trim();
+    let stripped = trimmed
+        .strip_prefix(&public_prefix)
+        .or_else(|| trimmed.strip_prefix(&signed_prefix))
+        .or_else(|| trimmed.strip_prefix(&raw_prefix))?;
+    // Drop query string from signed URLs.
+    let path = stripped.split('?').next().unwrap_or(stripped);
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+/// Extract `scenes[].imageUrl` strings from a marzipano_config JSONB value.
+/// Tolerant to slight schema variations: also accepts `image` and `url` keys.
+fn extract_panorama_urls(cfg: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    let scenes = match cfg {
+        Value::Array(arr) => arr.as_slice(),
+        Value::Object(map) => {
+            // `{ "scenes": [...] }` shape
+            if let Some(Value::Array(arr)) = map.get("scenes") {
+                arr.as_slice()
+            } else {
+                return out;
+            }
+        }
+        _ => return out,
+    };
+    for scene in scenes {
+        let Some(obj) = scene.as_object() else {
+            continue;
+        };
+        for key in ["imageUrl", "image", "url"] {
+            if let Some(Value::String(s)) = obj.get(key) {
+                if !s.is_empty() {
+                    out.push(s.clone());
+                    break;
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Compute orphan candidates: listed objects that are not in `referenced`
+/// and whose `created_at` is older than `min_age` (objects with no
+/// `created_at` are still considered candidates — the referenced-set diff
+/// is authoritative).
+fn diff_orphans(
+    listed: &[(String, Option<DateTime<Utc>>)],
+    referenced: &HashSet<String>,
+    min_age: Duration,
+    now: DateTime<Utc>,
+) -> Vec<String> {
+    let cutoff = now - min_age;
+    listed
+        .iter()
+        .filter(|(path, created)| {
+            if referenced.contains(path) {
+                return false;
+            }
+            match created {
+                Some(c) => *c < cutoff,
+                None => true,
+            }
+        })
+        .map(|(path, _)| path.clone())
+        .collect()
+}
+
+fn chunk_for_delete(paths: &[String], chunk_size: usize) -> impl Iterator<Item = &[String]> {
+    paths.chunks(chunk_size.max(1))
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_path_from_public_url() {
+        let url = "https://abc.supabase.co/storage/v1/object/public/event-images/club-1/abc.jpg";
+        let got = reference_path_from_url(url, "https://abc.supabase.co", "event-images");
+        assert_eq!(got, Some("club-1/abc.jpg".into()));
+    }
+
+    #[test]
+    fn reference_path_from_signed_url_drops_query() {
+        let url =
+            "https://abc.supabase.co/storage/v1/object/sign/panoramas/scene/file.jpg?token=xyz";
+        let got = reference_path_from_url(url, "https://abc.supabase.co", "panoramas");
+        assert_eq!(got, Some("scene/file.jpg".into()));
+    }
+
+    #[test]
+    fn reference_path_returns_none_for_other_buckets() {
+        let url = "https://abc.supabase.co/storage/v1/object/public/other/x.jpg";
+        let got = reference_path_from_url(url, "https://abc.supabase.co", "event-images");
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn reference_path_returns_none_for_non_supabase_url() {
+        let url = "https://example.com/foo.jpg";
+        let got = reference_path_from_url(url, "https://abc.supabase.co", "event-images");
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn extract_scenes_array_shape() {
+        let cfg = json!([
+            { "id": "a", "imageUrl": "https://abc.supabase.co/storage/v1/object/public/panoramas/a.jpg" },
+            { "id": "b", "imageUrl": "https://abc.supabase.co/storage/v1/object/public/panoramas/b.jpg" },
+        ]);
+        let got = extract_panorama_urls(&cfg);
+        assert_eq!(got.len(), 2);
+        assert!(got[0].ends_with("/a.jpg"));
+        assert!(got[1].ends_with("/b.jpg"));
+    }
+
+    #[test]
+    fn extract_scenes_object_shape() {
+        let cfg = json!({
+            "scenes": [{ "imageUrl": "x.jpg" }, { "image": "y.jpg" }, { "url": "z.jpg" }],
+        });
+        let got = extract_panorama_urls(&cfg);
+        assert_eq!(got, vec!["x.jpg", "y.jpg", "z.jpg"]);
+    }
+
+    #[test]
+    fn extract_scenes_skips_empty_and_unknown() {
+        let cfg = json!([{ "imageUrl": "" }, { "noUrl": true }]);
+        let got = extract_panorama_urls(&cfg);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn diff_orphans_filters_referenced_and_too_young() {
+        let now = Utc::now();
+        let referenced: HashSet<String> = ["keep.jpg".into()].into_iter().collect();
+        let listed = vec![
+            ("keep.jpg".into(), Some(now - Duration::hours(48))),
+            ("old-orphan.jpg".into(), Some(now - Duration::hours(48))),
+            ("young-orphan.jpg".into(), Some(now - Duration::hours(1))),
+            ("no-ts-orphan.jpg".into(), None),
+        ];
+        let got = diff_orphans(&listed, &referenced, Duration::hours(24), now);
+        assert_eq!(
+            got.into_iter().collect::<HashSet<_>>(),
+            ["old-orphan.jpg".into(), "no-ts-orphan.jpg".into()]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn chunk_for_delete_respects_size() {
+        let paths: Vec<String> = (0..250).map(|i| format!("p{i}")).collect();
+        let chunks: Vec<&[String]> = chunk_for_delete(&paths, 100).collect();
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].len(), 100);
+        assert_eq!(chunks[1].len(), 100);
+        assert_eq!(chunks[2].len(), 50);
+    }
+}

--- a/rust_BE/src/services/garbage_collector/table_images_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/table_images_orphans.rs
@@ -1,0 +1,58 @@
+//! Safety-net cleaner: table_images whose table no longer exists.
+//! `table_id` already has `ON DELETE CASCADE`.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM table_images ti
+        WHERE NOT EXISTS (SELECT 1 FROM tables t WHERE t.id = ti.table_id)
+          AND ti.created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM table_images ti
+            WHERE NOT EXISTS (SELECT 1 FROM tables t WHERE t.id = ti.table_id)
+              AND ti.created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "table_images_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/tables_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/tables_orphans.rs
@@ -1,0 +1,58 @@
+//! Safety-net cleaner: tables whose event no longer exists.
+//! `tables.event_id` already has `ON DELETE CASCADE`.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM tables t
+        WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.id = t.event_id)
+          AND t.created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM tables t
+            WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.id = t.event_id)
+              AND t.created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "tables_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/garbage_collector/tickets_orphans.rs
+++ b/rust_BE/src/services/garbage_collector/tickets_orphans.rs
@@ -1,0 +1,59 @@
+//! Safety-net cleaner: tickets whose event no longer exists.
+//! `tickets.event_id` already has `ON DELETE CASCADE`, so this should find
+//! zero rows in steady state. Useful if a future migration drops the FK.
+
+use sqlx::PgPool;
+
+use super::{CleanerCtx, CleanerStats};
+
+pub async fn run(pool: &PgPool, ctx: CleanerCtx) -> Result<CleanerStats, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let detected: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*)::bigint
+        FROM tickets t
+        WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.id = t.event_id)
+          AND t.created_at < NOW() - (INTERVAL '1 hour' * $1)
+        "#,
+    )
+    .bind(ctx.min_orphan_age_hours)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted = if ctx.dry_run {
+        0
+    } else {
+        sqlx::query(
+            r#"
+            DELETE FROM tickets t
+            WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.id = t.event_id)
+              AND t.created_at < NOW() - (INTERVAL '1 hour' * $1)
+            "#,
+        )
+        .bind(ctx.min_orphan_age_hours)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected()
+    };
+
+    if ctx.dry_run {
+        tx.rollback().await?;
+    } else {
+        tx.commit().await?;
+    }
+
+    tracing::info!(
+        cleaner = "tickets_orphans",
+        detected,
+        deleted,
+        dry_run = ctx.dry_run,
+        log_category = "gc",
+        "GC cleaner completed"
+    );
+
+    Ok(CleanerStats {
+        detected: detected as u64,
+        deleted,
+    })
+}

--- a/rust_BE/src/services/mod.rs
+++ b/rust_BE/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod garbage_collector;
 pub mod notification_service;
 pub mod sms_service;
 pub mod storage_service;


### PR DESCRIPTION
## Summary

Implements a daily garbage collection background job that detects and removes orphan rows from the database and orphan objects from Supabase Storage buckets. The job follows the existing background job pattern (`jobs/<name>.rs` + `record_job_run()`), is gated by `GC_ENABLED` configuration, and defaults to dry-run mode.

## Key Changes

### New Garbage Collector Service Module (`services/garbage_collector/`)
- **`mod.rs`**: Defines shared types `CleanerStats` (detected/deleted counts) and `CleanerCtx` (dry_run flag, min_orphan_age_hours)
- **`events_orphans.rs`**: Removes events with `club_id IS NULL` (real orphan source from `ON DELETE SET NULL` FK)
- **`payments_orphans.rs`**: Removes payments not referenced by any `reservation_payment_shares` (real orphan source with no formal FK)
- **`tickets_orphans.rs`, `tables_orphans.rs`, `reservations_orphans.rs`, `reservation_shares_orphans.rs`, `reservation_guests_orphans.rs`, `table_images_orphans.rs`**: Safety-net cleaners for tables with existing `ON DELETE CASCADE` constraints
- **`storage.rs`**: Handles Supabase Storage bucket cleanup
  - `run_event_images()` and `run_panoramas()` functions
  - Builds set of referenced storage paths from DB (events.image, table_images.url, marzipano_config URLs)
  - Lists bucket recursively via Supabase Storage REST API
  - Identifies unreferenced objects older than `min_orphan_age_hours`
  - Batch-deletes orphans in chunks of 100
  - Includes 9 unit tests for pure helper functions (URL parsing, scene extraction, set diff, chunking)

### New Background Job (`jobs/garbage_collector.rs`)
- Orchestrator with `pub async fn run(state: Arc<AppState>)` entry point
- Configurable initial delay and interval via `GC_FIRST_RUN_DELAY_SECONDS` and `GC_INTERVAL_SECONDS`
- Invokes all cleaners each round, isolating failures so one cleaner's error doesn't stop others
- Aggregates per-cleaner statistics and logs structured output
- Records one `background_job_runs` row per round with status (`success | partial_failure | failure`) and detailed cleaner results

### Configuration (`bootstrap/config.rs`)
- New `GcConfig` struct with environment variables:
  - `GC_ENABLED` (default: false)
  - `GC_DRY_RUN` (default: true)
  - `GC_INTERVAL_SECONDS` (default: 86400)
  - `GC_MIN_ORPHAN_AGE_HOURS` (default: 24)
  - `GC_FIRST_RUN_DELAY_SECONDS` (default: 300)
  - `SUPABASE_PANORAMAS_BUCKET` (optional; cleaner skipped if unset)

### Wiring
- `services/mod.rs`: Exports new `garbage_collector` module
- `jobs/mod.rs`: Conditionally spawns garbage collector job when `GC_ENABLED=true`; logs when disabled

## Implementation Details

- Each DB cleaner runs count + delete within a single transaction, rolling back in dry-run mode to observe counts without persisting changes
- Storage cleaners use Supabase Storage REST API with pagination (1000 items per page) and recursive folder traversal
- All cleaners respect `min_orphan_age_hours` to avoid deleting recently-created objects
- Comprehensive error handling with per-cleaner error isolation and aggregation
- Structured logging with `log_category = "gc"` for easy filtering

https://claude.ai/code/session_01HcATDGLNTN8WVLjPTuZSGQ