### PR TITLE
Refresh CLAUDE.md backend section and add lookup index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ docs/             — Architecture and API reference documentation
 ls DB/migrations/*.sql | sort | tail -1
 ```
 
-Migration file naming: `NNN_snake_case_description.sql` (zero-padded, e.g. `037_...`). Always add new migrations as the next numbered file — never edit existing ones.
+Migration file naming: `NNN_snake_case_description.sql` (zero-padded, e.g. `037_...`). Always add new migrations as the next numbered file — never edit existing ones. Note: a few historical numbers (029, 030, 042) have duplicates from concurrent branches; pick the next free number after the highest in `ls DB/migrations/`, do not re-use a duplicated one.
 
 ### Backend
 ```bash
@@ -85,21 +85,26 @@ VITE_API_URL=http://localhost:3000   # defaults to this if unset
 
 ### Backend (rust_BE/src/)
 
-**Layer order:** `models/` → `persistences/` → `controllers/` — never skip layers. All routes are registered in `main.rs`, no magic routing.
+**Layer order:** `api/routers/` → `controllers/` → `application/` → `infrastructure/repositories/` → `models/`. Not every entity has a service layer (older code calls repositories directly from the controller); newer code goes through `application/<entity>_service.rs`.
 
 ```
-main.rs            — Router setup, AppState initialization, middleware wiring
-controllers/       — HTTP handlers; extract request, call persistence, return JSON
-persistences/      — All SQLx queries; one file per entity
-models/            — Serde structs for DB rows and request/response bodies
-middleware/        — Auth extractors: AuthUser (any JWT) and ClubOwnerUser (role="club_owner")
-services/          — SMS via Twilio (sms_service.rs)
-idempotency/       — Deduplication for payment mutations
-logging/           — Structured JSON logging via tracing
-utils/jwt.rs       — JWT encode/decode
+main.rs                          — entrypoint; delegates to bootstrap
+bootstrap/                       — config.rs, state.rs (AppState), migrations.rs
+api/routers/<entity>.rs          — Axum route registration, one file per entity (composed in api/routers/mod.rs)
+api/errors.rs                    — ApiError envelope (use crate::api::errors::ApiError)
+controllers/<entity>_controller.rs       — HTTP handlers; extract request, call service or repository, return JSON
+application/<entity>_service.rs           — Business logic / orchestration (auth, payment, reservation, …)
+infrastructure/repositories/<entity>_persistence.rs  — All SQLx queries, one file per entity (formerly persistences/)
+infrastructure/outbox/, infrastructure/analytics/, infrastructure/logging/  — cross-cutting infra
+models/<entity>.rs               — Serde structs for DB rows and request/response bodies
+middleware/                      — auth.rs (AuthUser extractor), request_id.rs
+services/                        — SMS (sms_service.rs), storage (storage_service.rs), notifications, garbage_collector/
+jobs/                            — Tokio background tasks: garbage_collector, idempotency_cleanup, outbox_dispatcher, payment_maintenance
+idempotency/                     — Deduplication service for payment mutations
+utils/jwt.rs                     — JWT encode/decode
 ```
 
-`AppState` (shared via `Arc<AppState>`) holds: `db_pool`, `stripe_client`, `jwt_secret`, `idempotency_service`, `stripe_webhook_secret`.
+`AppState` (shared via `Arc<AppState>`, defined in `bootstrap/state.rs`) holds: `db_pool`, `stripe_client`, `jwt_secret`, `idempotency_service`, `stripe_webhook_secret`.
 
 **Auth extractors:**
 - User JWT: `AuthUser(claims): AuthUser` (from `middleware/auth.rs`)
@@ -108,10 +113,25 @@ utils/jwt.rs       — JWT encode/decode
 
 **Error responses** — always use the `ApiError` envelope with Italian messages:
 ```rust
-return Err(crate::models::ApiError::new(StatusCode::CONFLICT, "Messaggio in italiano"));
+return Err(crate::api::errors::ApiError::new(StatusCode::CONFLICT, "Messaggio in italiano"));
 ```
 
-**Adding a route:** register handler in `src/main.rs` → `create_router()`; add model structs to `src/models/`, add DB query to `src/persistences/`, implement logic in `src/controllers/`.
+**Adding a route:** add the route to the relevant `src/api/routers/<entity>.rs` (or create one and register it in `api/routers/mod.rs`); add the handler in `src/controllers/<entity>_controller.rs`; if the logic is non-trivial, put it in `src/application/<entity>_service.rs`; add the SQL in `src/infrastructure/repositories/<entity>_persistence.rs`; add request/response structs to `src/models/<entity>.rs`.
+
+**Where to look (saves a grep):**
+
+| Question | File / dir |
+|---|---|
+| Which routes exist for entity X? | `rust_BE/src/api/routers/<entity>.rs` |
+| Which routes does the club owner dashboard hit? | `rust_BE/src/api/routers/owner.rs` |
+| Stripe webhook handler | `rust_BE/src/controllers/webhook_controller.rs` |
+| Reservation + payment atomic creation | `rust_BE/src/controllers/table_controller.rs` (large; use service: `application/reservation_service.rs`) |
+| Split-payment guest pages (`/pay/:token`, `/payment-links/:token`) | `rust_BE/src/api/routers/reservations.rs` |
+| `ApiError` definition | `rust_BE/src/api/errors.rs` |
+| Background jobs (cleanup, outbox dispatch) | `rust_BE/src/jobs/` |
+| GC reference sets (marzipano, table images) | `rust_BE/src/services/garbage_collector/` |
+| Mobile data hook for entity X | `pierre_two/hooks/use<Entity>.tsx` |
+| Dashboard page for route `/dashboard/<x>` | `pierre_dashboard/src/pages/` (see Pages table above) |
 
 ### Mobile app (pierre_two/)
 

--- a/docs/daily-progress/2026-05-07-claudemd-backend-index.md
+++ b/docs/daily-progress/2026-05-07-claudemd-backend-index.md
@@ -1,0 +1,94 @@
+# 2026-05-07: CLAUDE.md backend index refresh
+
+**Branch**: `claude/graphify-token-savings-qkDtM`
+**Status**: Ready for review
+
+---
+
+## Overview
+
+Refreshed the Backend section of `CLAUDE.md` so the documented layout matches
+the current `rust_BE/src/` tree, and added a small "where to look" lookup
+table for the most common cross-file questions. Goal: cut the number of
+exploratory `grep`/`Read` calls future sessions need before they can edit
+backend code, as a low-cost alternative to installing a full knowledge-graph
+tool (Graphify) for the same purpose.
+
+---
+
+## Context
+
+The user asked whether installing Graphify (a build-time knowledge graph that
+plugs into Claude Code via a `PreToolUse` hook) would save tokens. Before
+adopting an external indexer with refresh/maintenance overhead, we agreed to
+try the cheaper baseline first: keep `CLAUDE.md` honest and add a small
+manual lookup index.
+
+While preparing the index, several entries in `CLAUDE.md` turned out to be
+stale relative to the current codebase:
+
+- Layer order described as `models → persistences → controllers`, but
+  `rust_BE/src/persistences/` no longer exists; queries live in
+  `rust_BE/src/infrastructure/repositories/<entity>_persistence.rs`.
+- Routes described as registered in `main.rs`, but they are now split into
+  `rust_BE/src/api/routers/<entity>.rs` and composed in
+  `api/routers/mod.rs`.
+- The `application/<entity>_service.rs` layer (orchestration / business
+  logic) was not mentioned at all.
+- `bootstrap/` (config, AppState, migrations) and `jobs/` (Tokio background
+  workers: GC, idempotency cleanup, outbox dispatcher, payment maintenance)
+  were missing from the directory listing.
+- `ApiError` was documented as `crate::models::ApiError`, but it now lives
+  at `crate::api::errors::ApiError` (see `rust_BE/src/api/errors.rs:9`).
+- The migration-numbering note didn't mention that `029`, `030`, and `042`
+  each have two files from concurrent branches, which makes the
+  `ls | sort | tail -1` recipe ambiguous.
+
+---
+
+## Changes
+
+### Documentation
+
+- **`CLAUDE.md`** — Backend section rewritten:
+  - Corrected layer order to
+    `api/routers → controllers → application → infrastructure/repositories → models`,
+    with a note that not every entity has a service layer yet.
+  - Replaced the directory listing with the current tree (`bootstrap/`,
+    `api/routers/`, `api/errors.rs`, `application/`,
+    `infrastructure/repositories/`, `infrastructure/outbox|analytics|logging/`,
+    `jobs/`, `services/`, `middleware/`, `idempotency/`, `utils/`).
+  - Updated `ApiError` import path in the example snippet.
+  - Rewrote the "Adding a route" recipe to walk through routers →
+    controller → service → repository → model.
+  - Added a "Where to look (saves a grep)" table mapping recurring questions
+    (Stripe webhook handler, reservation+payment atomic creation,
+    split-payment guest pages, GC reference sets, mobile data hooks,
+    dashboard pages) to specific files.
+- **`CLAUDE.md`** — Database section: appended a one-line warning that
+  numbers `029`, `030`, `042` are duplicated and the next migration must
+  use the next free number above the highest, not blindly `+1` from the
+  duplicated one.
+
+### Backend / Mobile / Dashboard / Database
+
+No code changes.
+
+---
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `CLAUDE.md` | Backend section refreshed; lookup table added; migration-duplicates note added |
+| `docs/daily-progress/2026-05-07-claudemd-backend-index.md` | New (this file) |
+
+---
+
+## Follow-ups
+
+- Re-evaluate Graphify after a few sessions: if exploratory grep volume is
+  still high despite the manual index, the marginal cost of a build-time
+  knowledge graph + refresh hook may be justified.
+- The Mobile and Dashboard sections of `CLAUDE.md` were not audited in this
+  pass; spot-check on the next mobile/dashboard task.


### PR DESCRIPTION
## Summary

Updated the Backend section of `CLAUDE.md` to reflect the current codebase structure and added a lookup table to reduce exploratory grep calls. This is a low-cost alternative to adopting an external knowledge-graph tool (Graphify) for the same purpose.

## Changes

- **Corrected layer order** from the outdated `models → persistences → controllers` to the current `api/routers → controllers → application → infrastructure/repositories → models`, with a note that not all entities have a service layer yet.

- **Updated directory listing** to match the actual `rust_BE/src/` structure:
  - Added missing directories: `bootstrap/`, `jobs/`, `infrastructure/outbox|analytics|logging/`
  - Corrected path: `persistences/` → `infrastructure/repositories/`
  - Corrected path: routes now in `api/routers/<entity>.rs` (composed in `api/routers/mod.rs`), not `main.rs`
  - Added `application/` layer for business logic and orchestration

- **Fixed import paths** in code examples:
  - `crate::models::ApiError` → `crate::api::errors::ApiError`
  - Updated `AppState` location reference to `bootstrap/state.rs`

- **Rewrote "Adding a route" recipe** to walk through the actual layer flow: routers → controller → service → repository → model.

- **Added "Where to look" lookup table** mapping common questions (Stripe webhook handler, reservation+payment atomic creation, split-payment pages, GC reference sets, mobile hooks, dashboard pages) to specific files, reducing the need for exploratory searches.

- **Added migration-duplicates warning** noting that historical numbers 029, 030, and 042 have duplicates from concurrent branches, and new migrations must use the next free number above the highest, not blindly increment from a duplicated one.

## Notes

No code changes to the backend, mobile, dashboard, or database implementations. This is purely documentation maintenance to keep `CLAUDE.md` honest and reduce friction for future sessions editing backend code.

https://claude.ai/code/session_01GRXbx7qTRdSnkiXNiJCCiP