### PR TITLE
Add dedicated club-images bucket and endpoint

### DIFF
--- a/docs/daily-progress/2026-05-07-club-images-bucket.md
+++ b/docs/daily-progress/2026-05-07-club-images-bucket.md
@@ -1,0 +1,98 @@
+# 2026-05-07: Dedicated `club-images` Storage Bucket
+
+**Branch**: `claude/fix-club-image-storage-GjF39`
+**Status**: Ready for review
+
+---
+
+## Overview
+
+Club logos were being uploaded into the `event-images` bucket via the same
+endpoint used for event posters (`POST /owner/events/image`). The dashboard
+reused `EventImageUpload` for the club settings form, so club logos and
+event locandine were piling up in the same bucket. This is logically wrong
+and operationally unsafe: the `event-images` GC cleaner builds its
+reference set from `events.image` and `table_images.url` only — it never
+looked at `clubs.image`, so the first GC run wiped the existing club
+logos.
+
+This change introduces a dedicated `club-images` bucket, a new
+`POST /owner/club/image` endpoint, and a matching GC cleaner that uses
+`clubs.image` (and `club_images.url`) as its reference set.
+
+---
+
+## Changes
+
+### Backend
+
+- `bootstrap/config.rs`: added `club_images_bucket` to `StorageConfig`,
+  reading `SUPABASE_CLUB_IMAGES_BUCKET` (default `club-images`).
+- `services/storage_service.rs`: renamed the standalone
+  `upload_event_image` to `upload_image_to_bucket` — the function already
+  takes the bucket as a parameter; the old name was misleading.
+- `controllers/club_image_controller.rs` (new): mirrors
+  `event_image_controller.rs` but writes into the new
+  `club_images_bucket`.
+- `api/routers/owner.rs`: registered `POST /owner/club/image`.
+- `services/garbage_collector/storage.rs`: added `run_club_images` and
+  `referenced_club_image_paths` (queries both `clubs.image` and
+  `club_images.url`).
+- `jobs/garbage_collector.rs`: wired `run_club_images` into the GC round
+  alongside the existing `event_images` and `panoramas` cleaners.
+
+### Dashboard
+
+- Renamed `components/EventImageUpload.tsx` to `components/ImageUpload.tsx`
+  and added a required `uploadEndpoint` prop plus optional `placeholder`
+  and `altText`. The endpoint is no longer hardcoded to
+  `/owner/events/image`.
+- `pages/ClubSettingsPage.tsx`: now uploads to `/owner/club/image`.
+- `pages/EventsPage.tsx`: continues to upload to `/owner/events/image`
+  via the same component.
+
+### Infrastructure / Notes
+
+- A `club-images` bucket must be created on Supabase (public read,
+  service-role write) before deploying. Same policy as `event-images`.
+- Optional env var `SUPABASE_CLUB_IMAGES_BUCKET` on Fly.io; default
+  `club-images` already matches the planned bucket name.
+- No DB migration: `clubs.image` schema is unchanged; only the host /
+  bucket portion of the URL changes for new uploads. Existing club logos
+  in `event-images` were already deleted by the prior GC run, so no data
+  migration is needed.
+
+---
+
+## Files Modified
+
+| Path | Change |
+|---|---|
+| `rust_BE/src/bootstrap/config.rs` | added `club_images_bucket` field + env parsing |
+| `rust_BE/src/services/storage_service.rs` | renamed `upload_event_image` -> `upload_image_to_bucket` |
+| `rust_BE/src/controllers/club_image_controller.rs` | **new** handler for club logo upload |
+| `rust_BE/src/controllers/event_image_controller.rs` | updated call site to renamed service fn |
+| `rust_BE/src/controllers/mod.rs` | exported `club_image_controller` |
+| `rust_BE/src/api/routers/owner.rs` | registered `POST /owner/club/image` |
+| `rust_BE/src/services/garbage_collector/storage.rs` | added `run_club_images` + reference set |
+| `rust_BE/src/jobs/garbage_collector.rs` | wired club-images cleaner into GC round |
+| `pierre_dashboard/src/components/ImageUpload.tsx` | renamed from `EventImageUpload`, parametric endpoint |
+| `pierre_dashboard/src/pages/ClubSettingsPage.tsx` | uses `/owner/club/image` |
+| `pierre_dashboard/src/pages/EventsPage.tsx` | passes `/owner/events/image` explicitly |
+
+---
+
+## Verification
+
+- `cd rust_BE && cargo check` clean.
+- `cargo test storage::` — all 9 unit tests in
+  `services/garbage_collector/storage.rs` pass.
+- `cd pierre_dashboard && npm run build` succeeds.
+- Manual end-to-end (post-deploy):
+  - Upload a logo from `/dashboard/club` and confirm `clubs.image`
+    contains `/storage/v1/object/public/club-images/<club_id>/...`.
+  - Upload a locandina from `/dashboard/events` and confirm the URL
+    still points at `event-images`.
+  - With `GC_ENABLED=true GC_DRY_RUN=true`, log line
+    `cleaner = "storage_club_images"` should appear with `detected = 0`
+    when the bucket only holds referenced objects.

--- a/pierre_dashboard/src/components/ImageUpload.tsx
+++ b/pierre_dashboard/src/components/ImageUpload.tsx
@@ -5,12 +5,21 @@ import { getSafeImageUrl } from '../utils/image';
 
 type UploadState = 'idle' | 'uploading' | 'done' | 'error';
 
-interface EventImageUploadProps {
+interface ImageUploadProps {
   currentUrl?: string;
   onUploaded: (url: string) => void;
+  uploadEndpoint: string;
+  placeholder?: string;
+  altText?: string;
 }
 
-export default function EventImageUpload({ currentUrl, onUploaded }: EventImageUploadProps) {
+export default function ImageUpload({
+  currentUrl,
+  onUploaded,
+  uploadEndpoint,
+  placeholder = 'Clicca per caricare la locandina',
+  altText = 'Immagine',
+}: ImageUploadProps) {
   const { token } = useAuth();
   const inputRef = useRef<HTMLInputElement>(null);
   const [uploadState, setUploadState] = useState<UploadState>('idle');
@@ -37,7 +46,7 @@ export default function EventImageUpload({ currentUrl, onUploaded }: EventImageU
       const formData = new FormData();
       formData.append('file', file);
 
-      const res = await fetch(`${API_URL}/owner/events/image`, {
+      const res = await fetch(`${API_URL}${uploadEndpoint}`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: formData,
@@ -62,7 +71,7 @@ export default function EventImageUpload({ currentUrl, onUploaded }: EventImageU
     <div>
       {previewSrc ? (
         <div className="relative w-full h-40 rounded-lg overflow-hidden border border-gray-200 mb-2">
-          <img src={previewSrc} alt="Locandina" className="w-full h-full object-cover" />
+          <img src={previewSrc} alt={altText} className="w-full h-full object-cover" />
           {uploadState === 'uploading' && (
             <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
               <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
@@ -90,7 +99,7 @@ export default function EventImageUpload({ currentUrl, onUploaded }: EventImageU
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
                   d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
-              <span className="text-sm">Clicca per caricare la locandina</span>
+              <span className="text-sm">{placeholder}</span>
               <span className="text-xs mt-1">JPG, PNG, WEBP — max 5 MB</span>
             </>
           )}

--- a/pierre_dashboard/src/pages/ClubSettingsPage.tsx
+++ b/pierre_dashboard/src/pages/ClubSettingsPage.tsx
@@ -16,7 +16,7 @@ import type {
   StripeOnboardingLinkResponse,
 } from '../types';
 import { trackEvent } from '../config/analytics';
-import EventImageUpload from '../components/EventImageUpload';
+import ImageUpload from '../components/ImageUpload';
 
 type StripeTone = 'slate' | 'green' | 'amber' | 'rose';
 
@@ -355,9 +355,12 @@ export default function ClubSettingsPage() {
         <form onSubmit={handleSave} className="space-y-5">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Immagine locale</label>
-            <EventImageUpload
+            <ImageUpload
               currentUrl={image || undefined}
               onUploaded={(url) => setImage(url)}
+              uploadEndpoint="/owner/club/image"
+              placeholder="Clicca per caricare il logo"
+              altText="Logo del club"
             />
           </div>
 

--- a/pierre_dashboard/src/pages/EventsPage.tsx
+++ b/pierre_dashboard/src/pages/EventsPage.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../config/api";
 import type { EventResponse, Genre } from "../types";
 import { trackEvent } from "../config/analytics";
-import EventImageUpload from "../components/EventImageUpload";
+import ImageUpload from "../components/ImageUpload";
 import { formatPrice, priceToApiString } from "../utils/currency";
 import { getSafeImageUrl } from "../utils/image";
 import { EmptyState, PageHeader, SectionCard } from "../components/ui";
@@ -311,9 +311,11 @@ export default function EventsPage() {
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Locandina
                 </label>
-                <EventImageUpload
+                <ImageUpload
                   currentUrl={form.image || undefined}
                   onUploaded={(url) => setForm((f) => ({ ...f, image: url }))}
+                  uploadEndpoint="/owner/events/image"
+                  altText="Locandina"
                 />
               </div>
 

--- a/rust_BE/src/api/routers/owner.rs
+++ b/rust_BE/src/api/routers/owner.rs
@@ -14,6 +14,7 @@ use crate::controllers::club_owner_controller::{
     update_club_marzipano_config_handler, update_event_marzipano_config_handler, update_my_club,
     update_reservation_handler, update_reservation_status_handler, upload_panorama_handler,
 };
+use crate::controllers::club_image_controller::upload_club_image;
 use crate::controllers::event_image_controller::upload_event_image;
 
 pub fn router() -> Router<Arc<AppState>> {
@@ -35,6 +36,10 @@ pub fn router() -> Router<Arc<AppState>> {
         .route(
             "/owner/club/marzipano-config",
             axum::routing::put(update_club_marzipano_config_handler),
+        )
+        .route(
+            "/owner/club/image",
+            axum::routing::post(upload_club_image),
         )
         .route(
             "/owner/events",

--- a/rust_BE/src/bootstrap/config.rs
+++ b/rust_BE/src/bootstrap/config.rs
@@ -58,6 +58,7 @@ pub struct StorageConfig {
     pub supabase_url: Option<String>,
     pub supabase_service_role_key: Option<String>,
     pub event_images_bucket: String,
+    pub club_images_bucket: String,
     pub panoramas_bucket: String,
     pub max_panorama_bytes: usize,
 }
@@ -209,6 +210,8 @@ impl AppConfig {
             .filter(|s| !s.is_empty());
         let event_images_bucket =
             env::var("SUPABASE_EVENT_IMAGES_BUCKET").unwrap_or_else(|_| "event-images".to_string());
+        let club_images_bucket =
+            env::var("SUPABASE_CLUB_IMAGES_BUCKET").unwrap_or_else(|_| "club-images".to_string());
         let panoramas_bucket =
             env::var("SUPABASE_PANORAMAS_BUCKET").unwrap_or_else(|_| "panoramas".to_string());
         let max_panorama_bytes = env::var("MAX_PANORAMA_BYTES")
@@ -279,6 +282,7 @@ impl AppConfig {
                 supabase_url,
                 supabase_service_role_key,
                 event_images_bucket,
+                club_images_bucket,
                 panoramas_bucket,
                 max_panorama_bytes,
             },

--- a/rust_BE/src/controllers/club_image_controller.rs
+++ b/rust_BE/src/controllers/club_image_controller.rs
@@ -10,15 +10,14 @@ use axum::{
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// Upload a locandina image for an event.
+/// Upload a logo image for a club.
 /// Accepts multipart/form-data with a field named "file".
 /// Returns { "url": "<public_url>" } on success.
-pub async fn upload_event_image(
+pub async fn upload_club_image(
     ClubOwnerUser(claims): ClubOwnerUser,
     State(state): State<Arc<AppState>>,
     mut multipart: Multipart,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    // Verify storage is configured
     let (supabase_url, service_role_key) = match (
         state.config.storage.supabase_url.as_deref(),
         state.config.storage.supabase_service_role_key.as_deref(),
@@ -30,14 +29,12 @@ pub async fn upload_event_image(
         }
     };
 
-    // Resolve the club_id for the authenticated owner
     let owner_id = Uuid::parse_str(&claims.sub).map_err(|_| StatusCode::UNAUTHORIZED)?;
     let club = club_persistence::get_club_by_owner_id(&state.db_pool, owner_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    // Extract the "file" field from the multipart body
     while let Some(field) = multipart
         .next_field()
         .await
@@ -56,20 +53,19 @@ pub async fn upload_event_image(
             &state.http_client,
             &supabase_url,
             &service_role_key,
-            &state.config.storage.event_images_bucket,
+            &state.config.storage.club_images_bucket,
             club.id,
             bytes,
             &content_type,
         )
         .await
         .map_err(|e| {
-            tracing::warn!(error = %e, "Evento image upload fallito");
+            tracing::warn!(error = %e, "Club image upload fallito");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
         return Ok(Json(serde_json::json!({ "url": url })));
     }
 
-    // No "file" field found
     Err(StatusCode::BAD_REQUEST)
 }

--- a/rust_BE/src/controllers/mod.rs
+++ b/rust_BE/src/controllers/mod.rs
@@ -1,6 +1,7 @@
 pub mod area_controller;
 pub mod auth_controller;
 pub mod club_controller;
+pub mod club_image_controller;
 pub mod club_owner_controller;
 pub mod event_controller;
 pub mod event_image_controller;

--- a/rust_BE/src/jobs/garbage_collector.rs
+++ b/rust_BE/src/jobs/garbage_collector.rs
@@ -135,6 +135,22 @@ async fn run_round(state: &AppState) {
     );
 
     record_storage(
+        "storage_club_images",
+        storage::run_club_images(
+            &state.db_pool,
+            &state.http_client,
+            &state.config.storage,
+            ctx,
+        )
+        .await,
+        &mut details,
+        &mut total_detected,
+        &mut total_deleted,
+        &mut succeeded,
+        &mut failed,
+    );
+
+    record_storage(
         "storage_panoramas",
         storage::run_panoramas(
             &state.db_pool,

--- a/rust_BE/src/services/garbage_collector/storage.rs
+++ b/rust_BE/src/services/garbage_collector/storage.rs
@@ -54,6 +54,29 @@ pub async fn run_event_images(
     .await
 }
 
+pub async fn run_club_images(
+    pool: &PgPool,
+    http: &reqwest::Client,
+    storage: &StorageConfig,
+    ctx: CleanerCtx,
+) -> Result<CleanerStats, String> {
+    let (supabase_url, service_key) = require_storage(storage)?;
+    let bucket = storage.club_images_bucket.as_str();
+
+    let referenced = referenced_club_image_paths(pool, supabase_url, bucket).await?;
+
+    run_bucket(
+        http,
+        supabase_url,
+        service_key,
+        bucket,
+        "storage_club_images",
+        &referenced,
+        ctx,
+    )
+    .await
+}
+
 pub async fn run_panoramas(
     pool: &PgPool,
     http: &reqwest::Client,
@@ -158,6 +181,39 @@ async fn referenced_event_image_paths(
         }
     }
     for (url,) in table_rows {
+        if let Some(p) = reference_path_from_url(&url, supabase_url, bucket) {
+            set.insert(p);
+        }
+    }
+    Ok(set)
+}
+
+async fn referenced_club_image_paths(
+    pool: &PgPool,
+    supabase_url: &str,
+    bucket: &str,
+) -> Result<HashSet<String>, String> {
+    let club_rows: Vec<(Option<String>,)> =
+        sqlx::query_as("SELECT image FROM clubs WHERE image IS NOT NULL AND image <> ''")
+            .fetch_all(pool)
+            .await
+            .map_err(|e| format!("failed to load club images: {e}"))?;
+
+    // The `club_images` gallery table can also point at this bucket; include
+    // its URLs so the GC doesn't wipe still-referenced gallery objects.
+    let gallery_rows: Vec<(String,)> =
+        sqlx::query_as("SELECT url FROM club_images WHERE url IS NOT NULL AND url <> ''")
+            .fetch_all(pool)
+            .await
+            .map_err(|e| format!("failed to load club gallery images: {e}"))?;
+
+    let mut set = HashSet::new();
+    for (url,) in club_rows.into_iter().filter_map(|(u,)| u.map(|u| (u,))) {
+        if let Some(p) = reference_path_from_url(&url, supabase_url, bucket) {
+            set.insert(p);
+        }
+    }
+    for (url,) in gallery_rows {
         if let Some(p) = reference_path_from_url(&url, supabase_url, bucket) {
             set.insert(p);
         }

--- a/rust_BE/src/services/storage_service.rs
+++ b/rust_BE/src/services/storage_service.rs
@@ -145,7 +145,7 @@ fn sanitize_filename(name: &str) -> String {
     }
 }
 
-// ─── Standalone function for event image uploads (used by event_image_controller) ─
+// ─── Standalone function for image uploads (used by event/club image controllers) ─
 
 fn ext_for(content_type: &str) -> &str {
     match content_type {
@@ -155,7 +155,7 @@ fn ext_for(content_type: &str) -> &str {
     }
 }
 
-pub async fn upload_event_image(
+pub async fn upload_image_to_bucket(
     client: &reqwest::Client,
     supabase_url: &str,
     service_role_key: &str,


### PR DESCRIPTION
## Summary

Club logos were previously uploaded to the `event-images` bucket via the same endpoint used for event posters, causing them to be deleted by the event-images garbage collector. This PR introduces a dedicated `club-images` storage bucket with its own upload endpoint and garbage collection logic.

## Changes

**Backend:**
- Added `club_images_bucket` configuration field to `StorageConfig` (reads `SUPABASE_CLUB_IMAGES_BUCKET`, defaults to `club-images`)
- Renamed `upload_event_image()` to `upload_image_to_bucket()` in storage service to reflect its generic nature
- Created new `club_image_controller.rs` with `upload_club_image()` handler that mirrors the event image controller but targets the club-images bucket
- Registered `POST /owner/club/image` endpoint in owner router
- Added `run_club_images()` garbage collector function that references both `clubs.image` and `club_images.url` tables
- Integrated club-images cleaner into the garbage collection round

**Dashboard:**
- Renamed `EventImageUpload.tsx` to `ImageUpload.tsx` and made it generic by:
  - Adding required `uploadEndpoint` prop (no longer hardcoded to `/owner/events/image`)
  - Adding optional `placeholder` and `altText` props for customization
- Updated `ClubSettingsPage.tsx` to use `ImageUpload` with `/owner/club/image` endpoint
- Updated `EventsPage.tsx` to explicitly pass `/owner/events/image` endpoint to the renamed component

## Implementation Details

- No database migration required; `clubs.image` schema unchanged
- Existing club logos in `event-images` were already deleted by prior GC runs
- The `club-images` bucket must be created on Supabase with public read/service-role write permissions (same policy as `event-images`)
- Optional environment variable `SUPABASE_CLUB_IMAGES_BUCKET` on Fly.io; defaults to `club-images`
- All unit tests pass; cargo check and npm build succeed

https://claude.ai/code/session_01N4J82Ks72rMBGHMwyKpYpP