### PR TITLE
Clean up rust_BE dead code: 28 → 0 warnings

### DIFF
--- a/docs/daily-progress/2026-05-08-rust-warnings-cleanup.md
+++ b/docs/daily-progress/2026-05-08-rust-warnings-cleanup.md
@@ -1,0 +1,122 @@
+# 2026-05-08: Rust backend dead-code cleanup
+
+**Branch**: `claude/fix-rust-warnings-3DUM6`
+**Status**: Ready for review
+
+---
+
+## Overview
+
+`cargo check` on `rust_BE/` was emitting 28 warnings, all variants of
+`dead_code` / `unused_imports`. The warnings hid genuine signal (an old
+`AppError` envelope competing with the documented `ApiError` flow, two
+`generate_payment_link_token` definitions, a duplicate `delete_table_image`,
+and a large block of split-payment repository code that had been superseded
+by the inline transactional flow in `reservation_service.rs`).
+
+This pass removes the dead code and silences the unavoidable
+SQLx-FromRow field warnings with `#[allow(dead_code)]`. After the cleanup
+`cargo check` reports 0 warnings on our own crate (the only remaining notice
+is a future-incompat warning from `sqlx-postgres v0.7.4`, an upstream
+dependency).
+
+---
+
+## Changes
+
+### Backend
+
+- **`src/api/errors.rs`** — collapsed the `AppError` envelope into `ApiError`
+  directly. The whole `AppError` struct, its `validation` / `unauthorized` /
+  `forbidden` / `not_found` / `conflict` / `external_dependency` / `internal`
+  constructors, the `AppResult` type alias, and the
+  `From<StatusCode>` / `From<sqlx::Error>` / `IntoResponse` impls were never
+  called outside of `ApiError::new`'s internal delegation. `ApiError::new`
+  now computes the code and returns the `(StatusCode, Json<ApiError>)` tuple
+  directly, matching the pattern used everywhere in the controllers (see
+  `CLAUDE.md` "Error responses" section).
+- **`src/models/mod.rs`** — removed the `AppError` / `AppResult` re-export
+  and the unused `PaymentShareResponse` / `ReservationGuest` re-exports.
+- **`src/infrastructure/repositories/club_owner_persistence.rs`** — deleted
+  `delete_table_image`. The controller (`delete_table_image_handler`) calls
+  `delete_table_image_for_club`, which authorises by club. The unscoped
+  variant was an unused historical leftover.
+- **`src/infrastructure/repositories/table_persistence.rs`** — deleted nine
+  split-payment / free-guest functions that nothing called any more:
+  `add_guest_to_reservation`, `generate_payment_link_token` (a duplicate of
+  the one inlined in `table_controller.rs` at line 1114),
+  `create_payment_share`, `get_payment_share_by_token`,
+  `update_payment_share_paid`, `add_free_guest`,
+  `get_free_guests_by_reservation`, `get_total_people_count`,
+  `increment_reservation_amount_paid`, `update_reservation_num_people`. The
+  active split-payment helpers (`get_reservation_by_payment_link_token`,
+  `get_payment_share_by_checkout_session`, `get_payment_shares_by_reservation`,
+  `set_payment_share_checkout_session`, `check_and_confirm_reservation`)
+  are kept untouched. The stale `ReservationGuest` import was dropped from
+  the file header.
+- **`src/infrastructure/repositories/payment_persistence.rs`** — removed
+  `load_payment_by_stripe_id` (never called; webhook uses a different
+  lookup).
+- **`src/infrastructure/repositories/ticket_persistence.rs`** — removed
+  `get_tickets_by_user_id` (mobile uses a different aggregated query).
+- **`src/infrastructure/logging/mod.rs`** — removed the trio
+  `log_business_event` / `log_dependency_event` / `log_security_event`. They
+  were a planned observability surface that nothing emits to today; can be
+  re-introduced when an actual call site lands.
+- **`src/services/storage_service.rs`** — removed the unused
+  `StorageService::is_configured` helper.
+- **`src/models/table.rs`** — removed dead request/row structs:
+  `CreateReservationWithPaymentRequest`, `TableReservationPayment`,
+  `TableReservationTicket`, `CreatePaymentIntentRequest`,
+  `ReservationGuest`. The replacement flow uses
+  `CreateSplitReservationRequest` / `CreateSplitPaymentIntentRequest` and
+  the per-share `ReservationPaymentShare` row.
+- **`src/models/payment.rs`** — removed `PaymentResponse` (controllers
+  return `CapturePaymentResponse` / `CancelPaymentResponse` instead).
+- **`src/infrastructure/outbox/mod.rs`** — annotated `OutboxEvent` with
+  `#[allow(dead_code)]`. Six fields (`aggregate_type`, `status`,
+  `available_at`, `last_error`, `created_at`, `processed_at`) are populated
+  by SQLx via `#[derive(FromRow)]` for diagnostics but the dispatcher only
+  reads `id`, `event_type`, `aggregate_id`, `payload`, `attempts`. The
+  fields are intentionally hydrated for log/debug visibility.
+- **`src/bootstrap/config.rs`** — annotated
+  `FeatureFlagsConfig.bootstrap_flags_from_env` with
+  `#[allow(dead_code)]`. The env var is parsed at startup so the build
+  carries the configured value for the future provider implementation, but
+  no consumer reads it yet.
+
+### Dashboard / Mobile / Database
+
+No code changes.
+
+---
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `rust_BE/src/api/errors.rs` | Collapsed `AppError` into `ApiError`; deleted unused constructors / impls |
+| `rust_BE/src/models/mod.rs` | Removed dead re-exports (`AppError`, `AppResult`, `PaymentShareResponse`, `ReservationGuest`) |
+| `rust_BE/src/models/table.rs` | Removed 5 unused request/row structs |
+| `rust_BE/src/models/payment.rs` | Removed unused `PaymentResponse` |
+| `rust_BE/src/infrastructure/repositories/club_owner_persistence.rs` | Removed unscoped `delete_table_image` duplicate |
+| `rust_BE/src/infrastructure/repositories/table_persistence.rs` | Removed 9 dead split-payment helpers + stale import |
+| `rust_BE/src/infrastructure/repositories/payment_persistence.rs` | Removed `load_payment_by_stripe_id` |
+| `rust_BE/src/infrastructure/repositories/ticket_persistence.rs` | Removed `get_tickets_by_user_id` |
+| `rust_BE/src/infrastructure/logging/mod.rs` | Removed 3 unused event helpers |
+| `rust_BE/src/infrastructure/outbox/mod.rs` | `#[allow(dead_code)]` on `OutboxEvent` (SQLx-mapped DB columns) |
+| `rust_BE/src/services/storage_service.rs` | Removed unused `StorageService::is_configured` |
+| `rust_BE/src/bootstrap/config.rs` | `#[allow(dead_code)]` on `FeatureFlagsConfig.bootstrap_flags_from_env` |
+| `docs/daily-progress/2026-05-08-rust-warnings-cleanup.md` | New (this file) |
+
+---
+
+## Verification
+
+```bash
+cd rust_BE
+cargo fmt
+cargo check     # 0 warnings on our crate (only sqlx-postgres future-incompat from upstream)
+```
+
+Before: 28 warnings. After: 0.

--- a/rust_BE/src/api/errors.rs
+++ b/rust_BE/src/api/errors.rs
@@ -1,8 +1,4 @@
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    Json,
-};
+use axum::{http::StatusCode, Json};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -11,108 +7,19 @@ pub struct ApiError {
     pub code: String,
 }
 
-#[derive(Debug, Clone)]
-pub struct AppError {
-    pub status: StatusCode,
-    pub message: String,
-    pub code: String,
-}
-
-pub type AppResult<T> = Result<T, AppError>;
-
-impl AppError {
-    pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+impl ApiError {
+    pub fn new(status: StatusCode, message: impl Into<String>) -> (StatusCode, Json<ApiError>) {
         let code = status
             .canonical_reason()
             .unwrap_or("error")
             .to_lowercase()
             .replace(' ', "_");
-        Self {
-            status,
-            message: message.into(),
-            code,
-        }
-    }
-
-    pub fn response(
-        status: StatusCode,
-        message: impl Into<String>,
-    ) -> (StatusCode, Json<ApiError>) {
-        let err = Self::new(status, message);
         (
-            err.status,
+            status,
             Json(ApiError {
-                error: err.message,
-                code: err.code,
+                error: message.into(),
+                code,
             }),
         )
-    }
-
-    pub fn validation(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::BAD_REQUEST, message)
-    }
-
-    pub fn unauthorized(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::UNAUTHORIZED, message)
-    }
-
-    pub fn forbidden(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::FORBIDDEN, message)
-    }
-
-    pub fn not_found(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::NOT_FOUND, message)
-    }
-
-    pub fn conflict(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::CONFLICT, message)
-    }
-
-    pub fn external_dependency(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::BAD_GATEWAY, message)
-    }
-
-    pub fn internal(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::INTERNAL_SERVER_ERROR, message)
-    }
-}
-
-impl IntoResponse for AppError {
-    fn into_response(self) -> Response {
-        (
-            self.status,
-            Json(ApiError {
-                error: self.message,
-                code: self.code,
-            }),
-        )
-            .into_response()
-    }
-}
-
-impl From<StatusCode> for AppError {
-    fn from(status: StatusCode) -> Self {
-        Self::new(
-            status,
-            status.canonical_reason().unwrap_or("Request failed"),
-        )
-    }
-}
-
-impl From<sqlx::Error> for AppError {
-    fn from(error: sqlx::Error) -> Self {
-        match error {
-            sqlx::Error::RowNotFound => Self::new(StatusCode::NOT_FOUND, "Risorsa non trovata"),
-            other => {
-                tracing::error!(error = %other, "Database error");
-                Self::new(StatusCode::INTERNAL_SERVER_ERROR, "Errore interno")
-            }
-        }
-    }
-}
-
-impl ApiError {
-    pub fn new(status: StatusCode, message: impl Into<String>) -> (StatusCode, Json<ApiError>) {
-        AppError::response(status, message)
     }
 }

--- a/rust_BE/src/api/routers/owner.rs
+++ b/rust_BE/src/api/routers/owner.rs
@@ -3,18 +3,18 @@ use std::sync::Arc;
 use axum::{routing::get, Router};
 
 use crate::bootstrap::state::AppState;
+use crate::controllers::club_image_controller::upload_club_image;
 use crate::controllers::club_owner_controller::{
     add_my_club_image, add_table_image_handler, checkin_handler, create_club_event,
     create_club_table, create_manual_reservation_handler, create_my_club_stripe_onboarding_link,
     delete_club_event, delete_my_club_image, delete_reservation_handler,
-    delete_table_image_handler, duplicate_event_tables_handler, get_event_reservation_stats_handler,
-    get_event_reservations_handler, get_my_club, get_my_club_events, get_my_club_images,
-    get_my_club_stripe_status, get_my_club_tables, get_owner_stats_handler,
-    get_table_images_handler, scan_code_handler, update_club_event,
+    delete_table_image_handler, duplicate_event_tables_handler,
+    get_event_reservation_stats_handler, get_event_reservations_handler, get_my_club,
+    get_my_club_events, get_my_club_images, get_my_club_stripe_status, get_my_club_tables,
+    get_owner_stats_handler, get_table_images_handler, scan_code_handler, update_club_event,
     update_club_marzipano_config_handler, update_event_marzipano_config_handler, update_my_club,
     update_reservation_handler, update_reservation_status_handler, upload_panorama_handler,
 };
-use crate::controllers::club_image_controller::upload_club_image;
 use crate::controllers::event_image_controller::upload_event_image;
 
 pub fn router() -> Router<Arc<AppState>> {
@@ -37,10 +37,7 @@ pub fn router() -> Router<Arc<AppState>> {
             "/owner/club/marzipano-config",
             axum::routing::put(update_club_marzipano_config_handler),
         )
-        .route(
-            "/owner/club/image",
-            axum::routing::post(upload_club_image),
-        )
+        .route("/owner/club/image", axum::routing::post(upload_club_image))
         .route(
             "/owner/events",
             get(get_my_club_events).post(create_club_event),

--- a/rust_BE/src/bootstrap/config.rs
+++ b/rust_BE/src/bootstrap/config.rs
@@ -44,6 +44,7 @@ pub struct AnalyticsConfig {
 #[derive(Clone, Debug)]
 pub struct FeatureFlagsConfig {
     pub provider: String,
+    #[allow(dead_code)]
     pub bootstrap_flags_from_env: bool,
 }
 

--- a/rust_BE/src/bootstrap/migrations.rs
+++ b/rust_BE/src/bootstrap/migrations.rs
@@ -25,7 +25,12 @@ pub async fn run_startup_migrations(pool: &PgPool) -> Result<usize, String> {
 
     let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../DB/migrations");
     let mut migration_paths = fs::read_dir(&migrations_dir)
-        .map_err(|error| format!("failed to read migrations directory {:?}: {error}", migrations_dir))?
+        .map_err(|error| {
+            format!(
+                "failed to read migrations directory {:?}: {error}",
+                migrations_dir
+            )
+        })?
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
         .filter(|path| path.extension().is_some_and(|ext| ext == "sql"))
         .collect::<Vec<_>>();

--- a/rust_BE/src/controllers/area_controller.rs
+++ b/rust_BE/src/controllers/area_controller.rs
@@ -66,15 +66,10 @@ pub async fn create_area(
         .ok_or(StatusCode::NOT_FOUND)?;
 
     let price = Decimal::from_f64_retain(req.price).ok_or(StatusCode::BAD_REQUEST)?;
-    let area = area_persistence::create_area(
-        &state.db_pool,
-        club.id,
-        req.name,
-        price,
-        req.description,
-    )
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let area =
+        area_persistence::create_area(&state.db_pool, club.id, req.name, price, req.description)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok((StatusCode::CREATED, Json(AreaResponse::from(area))))
 }
@@ -107,15 +102,10 @@ pub async fn update_area(
         .map(|p| Decimal::from_f64_retain(p).ok_or(StatusCode::BAD_REQUEST))
         .transpose()?;
 
-    let area = area_persistence::update_area(
-        &state.db_pool,
-        area_uuid,
-        req.name,
-        price,
-        req.description,
-    )
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let area =
+        area_persistence::update_area(&state.db_pool, area_uuid, req.name, price, req.description)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(AreaResponse::from(area)))
 }

--- a/rust_BE/src/controllers/club_owner_controller.rs
+++ b/rust_BE/src/controllers/club_owner_controller.rs
@@ -1694,7 +1694,11 @@ pub async fn upload_panorama_handler(
     let mut content_type = String::from("image/jpeg");
     let mut file_bytes: Vec<u8> = Vec::new();
 
-    while let Some(field) = multipart.next_field().await.map_err(|_| StatusCode::BAD_REQUEST)? {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?
+    {
         let field_name = field.name().unwrap_or("").to_string();
         if field_name == "file" {
             if let Some(name) = field.file_name() {
@@ -1703,7 +1707,11 @@ pub async fn upload_panorama_handler(
             if let Some(ct) = field.content_type() {
                 content_type = ct.to_string();
             }
-            file_bytes = field.bytes().await.map_err(|_| StatusCode::BAD_REQUEST)?.to_vec();
+            file_bytes = field
+                .bytes()
+                .await
+                .map_err(|_| StatusCode::BAD_REQUEST)?
+                .to_vec();
         }
     }
 

--- a/rust_BE/src/controllers/event_controller.rs
+++ b/rust_BE/src/controllers/event_controller.rs
@@ -59,8 +59,7 @@ pub async fn get_all_events(
                     .await
                     .unwrap_or_default();
 
-            let mut responses =
-                event_responses_with_club_fallback(&state, events).await;
+            let mut responses = event_responses_with_club_fallback(&state, events).await;
             for r in responses.iter_mut() {
                 if let Ok(id) = Uuid::parse_str(&r.id) {
                     r.genres = genres_map.get(&id).cloned().unwrap_or_default();
@@ -245,11 +244,8 @@ pub(crate) async fn event_responses_with_club_fallback(
     let configs = if club_ids.is_empty() {
         std::collections::HashMap::new()
     } else {
-        match club_persistence::get_marzipano_configs_for_clubs(
-            &state.read_db_pool,
-            &club_ids,
-        )
-        .await
+        match club_persistence::get_marzipano_configs_for_clubs(&state.read_db_pool, &club_ids)
+            .await
         {
             Ok(map) => map,
             Err(error) => {

--- a/rust_BE/src/controllers/table_controller.rs
+++ b/rust_BE/src/controllers/table_controller.rs
@@ -601,13 +601,32 @@ pub async fn create_payment_intent(
     } else if let Some(ref aid) = req.area_id {
         let area_uuid = Uuid::parse_str(aid)
             .map_err(|_| (StatusCode::BAD_REQUEST, "ID area non valido".to_string()))?;
-        match table_persistence::find_first_available_table_by_area(&state.db_pool, area_uuid, event_id).await {
+        match table_persistence::find_first_available_table_by_area(
+            &state.db_pool,
+            area_uuid,
+            event_id,
+        )
+        .await
+        {
             Ok(t) => t,
-            Err(sqlx::Error::RowNotFound) => return Err((StatusCode::CONFLICT, "Nessun tavolo disponibile per questa area".to_string())),
-            Err(_) => return Err((StatusCode::INTERNAL_SERVER_ERROR, "Errore del database".to_string())),
+            Err(sqlx::Error::RowNotFound) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "Nessun tavolo disponibile per questa area".to_string(),
+                ))
+            }
+            Err(_) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Errore del database".to_string(),
+                ))
+            }
         }
     } else {
-        return Err((StatusCode::BAD_REQUEST, "Specificare table_id o area_id".to_string()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Specificare table_id o area_id".to_string(),
+        ));
     };
     let table_id = table.id;
 
@@ -790,13 +809,32 @@ pub async fn create_reservation_with_payment(
     } else if let Some(ref aid) = req.area_id {
         let area_uuid = Uuid::parse_str(aid)
             .map_err(|_| (StatusCode::BAD_REQUEST, "ID area non valido".to_string()))?;
-        match table_persistence::find_first_available_table_by_area(&state.db_pool, area_uuid, event_id).await {
+        match table_persistence::find_first_available_table_by_area(
+            &state.db_pool,
+            area_uuid,
+            event_id,
+        )
+        .await
+        {
             Ok(t) => (t.id, t),
-            Err(sqlx::Error::RowNotFound) => return Err((StatusCode::CONFLICT, "Nessun tavolo disponibile per questa area".to_string())),
-            Err(_) => return Err((StatusCode::INTERNAL_SERVER_ERROR, "Errore del database".to_string())),
+            Err(sqlx::Error::RowNotFound) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "Nessun tavolo disponibile per questa area".to_string(),
+                ))
+            }
+            Err(_) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Errore del database".to_string(),
+                ))
+            }
         }
     } else {
-        return Err((StatusCode::BAD_REQUEST, "Specificare table_id o area_id".to_string()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Specificare table_id o area_id".to_string(),
+        ));
     };
 
     tracing::info!(

--- a/rust_BE/src/infrastructure/logging/mod.rs
+++ b/rust_BE/src/infrastructure/logging/mod.rs
@@ -82,32 +82,3 @@ pub fn log_request_complete(
         "Request completed"
     );
 }
-
-pub fn log_business_event(event_name: &str, entity_type: &str, entity_id: &str) {
-    tracing::info!(
-        log_category = "business_event",
-        event_name,
-        entity_type,
-        entity_id,
-        "Business event"
-    );
-}
-
-pub fn log_dependency_event(dependency: &str, operation: &str, outcome: &str) {
-    tracing::info!(
-        log_category = "dependency",
-        dependency,
-        operation,
-        outcome,
-        "Dependency call"
-    );
-}
-
-pub fn log_security_event(event_name: &str, actor_id: Option<&str>) {
-    tracing::warn!(
-        log_category = "security",
-        event_name,
-        actor_id = actor_id.unwrap_or("anonymous"),
-        "Security event"
-    );
-}

--- a/rust_BE/src/infrastructure/outbox/mod.rs
+++ b/rust_BE/src/infrastructure/outbox/mod.rs
@@ -4,6 +4,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
+#[allow(dead_code)]
 pub struct OutboxEvent {
     pub id: Uuid,
     pub event_type: String,

--- a/rust_BE/src/infrastructure/repositories/club_owner_persistence.rs
+++ b/rust_BE/src/infrastructure/repositories/club_owner_persistence.rs
@@ -183,14 +183,6 @@ pub async fn add_table_image(
     Ok(row)
 }
 
-pub async fn delete_table_image(pool: &PgPool, image_id: Uuid) -> Result<bool> {
-    let result = sqlx::query(r#"DELETE FROM table_images WHERE id = $1"#)
-        .bind(image_id)
-        .execute(pool)
-        .await?;
-    Ok(result.rows_affected() > 0)
-}
-
 /// Delete a table image only if it belongs to a table whose event belongs to `club_id`.
 pub async fn delete_table_image_for_club(
     pool: &PgPool,

--- a/rust_BE/src/infrastructure/repositories/payment_persistence.rs
+++ b/rust_BE/src/infrastructure/repositories/payment_persistence.rs
@@ -65,24 +65,6 @@ pub async fn load_payment_service(
     .ok_or(StatusCode::NOT_FOUND)
 }
 
-// Helper function to get payment by Stripe payment intent ID
-pub async fn load_payment_by_stripe_id(
-    stripe_payment_intent_id: &str,
-    app_state: &AppState,
-) -> Result<PaymentEntity, StatusCode> {
-    sqlx::query_as::<_, PaymentEntity>(
-        "SELECT id, sender_id, receiver_id, amount, status, insert_date, update_date, stripe_payment_intent_id, user_ids, capture_method, authorization_status, authorized_at, captured_at, cancelled_at, authorized_amount, captured_amount, stripe_customer_id, stripe_payment_method_id FROM payments WHERE stripe_payment_intent_id = $1"
-    )
-    .bind(stripe_payment_intent_id)
-    .fetch_optional(&app_state.db_pool)
-    .await
-    .map_err(|e| {
-        error!(error = %e, stripe_payment_intent_id = %stripe_payment_intent_id, "Failed to load payment by Stripe ID");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)
-}
-
 use stripe::{CreatePaymentIntent, Currency, PaymentIntent};
 
 pub async fn create_payment_service(

--- a/rust_BE/src/infrastructure/repositories/table_persistence.rs
+++ b/rust_BE/src/infrastructure/repositories/table_persistence.rs
@@ -1,5 +1,5 @@
-use crate::models::{ReservationGuest, ReservationPaymentShare, Table, TableReservation};
 use crate::models::club_owner::EventReservationStatsResponse;
+use crate::models::{ReservationPaymentShare, Table, TableReservation};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -809,118 +809,9 @@ pub async fn add_ticket_to_reservation(
     Ok(())
 }
 
-/// Add a guest user to a reservation's guest_user_ids array
-pub async fn add_guest_to_reservation(
-    pool: &PgPool,
-    reservation_id: Uuid,
-    guest_user_id: Uuid,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        r#"
-        UPDATE table_reservations
-        SET guest_user_ids = array_append(COALESCE(guest_user_ids, '{}'), $1),
-            updated_at = NOW()
-        WHERE id = $2
-        "#,
-    )
-    .bind(guest_user_id)
-    .bind(reservation_id)
-    .execute(pool)
-    .await?;
-
-    Ok(())
-}
-
 // ============================================================================
 // Payment Shares (Split Payment)
 // ============================================================================
-
-/// Generate unique payment link token
-fn generate_payment_link_token() -> String {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    let token: String = (0..32)
-        .map(|_| {
-            let idx = rng.gen_range(0..36);
-            if idx < 26 {
-                (b'a' + idx) as char
-            } else {
-                (b'0' + (idx - 26)) as char
-            }
-        })
-        .collect();
-    format!("pay_{}", token)
-}
-
-/// Create a payment share for a reservation
-pub async fn create_payment_share(
-    pool: &PgPool,
-    reservation_id: Uuid,
-    user_id: Option<Uuid>,
-    phone_number: Option<String>,
-    amount: Decimal,
-    is_owner: bool,
-    status: &str,
-    stripe_payment_intent_id: Option<String>,
-) -> Result<ReservationPaymentShare, sqlx::Error> {
-    let payment_link_token = if !is_owner {
-        // Generate unique token, retry on collision
-        let mut token = generate_payment_link_token();
-        let mut attempts = 0;
-        while attempts < 10 {
-            let existing = sqlx::query_scalar::<_, i64>(
-                "SELECT COUNT(*) FROM reservation_payment_shares WHERE payment_link_token = $1",
-            )
-            .bind(&token)
-            .fetch_one(pool)
-            .await?;
-            if existing == 0 {
-                break;
-            }
-            token = generate_payment_link_token();
-            attempts += 1;
-        }
-        Some(token)
-    } else {
-        None
-    };
-
-    let share = sqlx::query_as::<_, ReservationPaymentShare>(
-        r#"
-        INSERT INTO reservation_payment_shares (
-            reservation_id, user_id, phone_number, amount, status,
-            stripe_payment_intent_id, payment_link_token, is_owner
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-        RETURNING *
-        "#,
-    )
-    .bind(reservation_id)
-    .bind(user_id)
-    .bind(phone_number)
-    .bind(amount)
-    .bind(status)
-    .bind(stripe_payment_intent_id)
-    .bind(payment_link_token)
-    .bind(is_owner)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(share)
-}
-
-/// Get payment share by token
-pub async fn get_payment_share_by_token(
-    pool: &PgPool,
-    token: &str,
-) -> Result<ReservationPaymentShare, sqlx::Error> {
-    sqlx::query_as::<_, ReservationPaymentShare>(
-        "SELECT * FROM reservation_payment_shares WHERE payment_link_token = $1",
-    )
-    .bind(token)
-    .fetch_one(pool)
-    .await
-}
 
 /// Get reservation by its shared payment_link_token (new single-link model)
 pub async fn get_reservation_by_payment_link_token(
@@ -961,29 +852,6 @@ pub async fn get_payment_shares_by_reservation(
     .await
 }
 
-/// Update payment share status and link Stripe IDs
-pub async fn update_payment_share_paid(
-    pool: &PgPool,
-    share_id: Uuid,
-    payment_id: Uuid,
-    stripe_payment_intent_id: Option<String>,
-) -> Result<ReservationPaymentShare, sqlx::Error> {
-    sqlx::query_as::<_, ReservationPaymentShare>(
-        r#"
-        UPDATE reservation_payment_shares
-        SET status = 'paid', payment_id = $1, stripe_payment_intent_id = COALESCE($2, stripe_payment_intent_id),
-            updated_at = NOW()
-        WHERE id = $3
-        RETURNING *
-        "#,
-    )
-    .bind(payment_id)
-    .bind(stripe_payment_intent_id)
-    .bind(share_id)
-    .fetch_one(pool)
-    .await
-}
-
 /// Set Stripe checkout session ID on a payment share
 pub async fn set_payment_share_checkout_session(
     pool: &PgPool,
@@ -1006,116 +874,6 @@ pub async fn set_payment_share_checkout_session(
     .bind(share_id)
     .fetch_one(pool)
     .await
-}
-
-// ============================================================================
-// Reservation Guests (Free / Non-paying)
-// ============================================================================
-
-/// Add a free guest to a reservation
-pub async fn add_free_guest(
-    pool: &PgPool,
-    reservation_id: Uuid,
-    user_id: Option<Uuid>,
-    phone_number: &str,
-    email: Option<String>,
-    name: Option<String>,
-    added_by: Uuid,
-    ticket_id: Option<Uuid>,
-) -> Result<ReservationGuest, sqlx::Error> {
-    sqlx::query_as::<_, ReservationGuest>(
-        r#"
-        INSERT INTO reservation_guests (reservation_id, user_id, phone_number, email, name, added_by, ticket_id)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
-        RETURNING *
-        "#,
-    )
-    .bind(reservation_id)
-    .bind(user_id)
-    .bind(phone_number)
-    .bind(email)
-    .bind(name)
-    .bind(added_by)
-    .bind(ticket_id)
-    .fetch_one(pool)
-    .await
-}
-
-/// Get all free guests for a reservation
-pub async fn get_free_guests_by_reservation(
-    pool: &PgPool,
-    reservation_id: Uuid,
-) -> Result<Vec<ReservationGuest>, sqlx::Error> {
-    sqlx::query_as::<_, ReservationGuest>(
-        "SELECT * FROM reservation_guests WHERE reservation_id = $1 ORDER BY created_at ASC",
-    )
-    .bind(reservation_id)
-    .fetch_all(pool)
-    .await
-}
-
-/// Count total people in a reservation (paying shares + free guests)
-pub async fn get_total_people_count(
-    pool: &PgPool,
-    reservation_id: Uuid,
-) -> Result<i64, sqlx::Error> {
-    let shares_count = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM reservation_payment_shares WHERE reservation_id = $1",
-    )
-    .bind(reservation_id)
-    .fetch_one(pool)
-    .await?;
-
-    let guests_count = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM reservation_guests WHERE reservation_id = $1",
-    )
-    .bind(reservation_id)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(shares_count + guests_count)
-}
-
-/// Update reservation amount_paid by adding a share amount
-pub async fn increment_reservation_amount_paid(
-    pool: &PgPool,
-    reservation_id: Uuid,
-    amount: Decimal,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        r#"
-        UPDATE table_reservations
-        SET amount_paid = amount_paid + $1, updated_at = NOW()
-        WHERE id = $2
-        "#,
-    )
-    .bind(amount)
-    .bind(reservation_id)
-    .execute(pool)
-    .await?;
-
-    Ok(())
-}
-
-/// Update reservation num_people
-pub async fn update_reservation_num_people(
-    pool: &PgPool,
-    reservation_id: Uuid,
-    num_people: i32,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        r#"
-        UPDATE table_reservations
-        SET num_people = $1, updated_at = NOW()
-        WHERE id = $2
-        "#,
-    )
-    .bind(num_people)
-    .bind(reservation_id)
-    .execute(pool)
-    .await?;
-
-    Ok(())
 }
 
 /// Check if all payment shares are paid and update reservation status if so

--- a/rust_BE/src/infrastructure/repositories/ticket_persistence.rs
+++ b/rust_BE/src/infrastructure/repositories/ticket_persistence.rs
@@ -20,23 +20,6 @@ pub async fn get_all_tickets(pool: &PgPool, limit: i64, offset: i64) -> Result<V
     Ok(tickets)
 }
 
-/// Get tickets for a specific user
-pub async fn get_tickets_by_user_id(pool: &PgPool, user_id: Uuid) -> Result<Vec<Ticket>> {
-    let tickets = sqlx::query_as::<_, Ticket>(
-        r#"
-        SELECT id, event_id, user_id, ticket_code, ticket_type, price, status, purchase_date, qr_code, created_at, updated_at
-        FROM tickets
-        WHERE user_id = $1
-        ORDER BY purchase_date DESC
-        "#,
-    )
-    .bind(user_id)
-    .fetch_all(pool)
-    .await?;
-
-    Ok(tickets)
-}
-
 /// Get a single ticket by ID
 pub async fn get_ticket_by_id(pool: &PgPool, ticket_id: Uuid) -> Result<Option<Ticket>> {
     let ticket = sqlx::query_as::<_, Ticket>(

--- a/rust_BE/src/main.rs
+++ b/rust_BE/src/main.rs
@@ -1,7 +1,7 @@
 use dotenv::dotenv;
 use std::fs;
-use std::path::PathBuf;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 

--- a/rust_BE/src/models/mod.rs
+++ b/rust_BE/src/models/mod.rs
@@ -32,12 +32,11 @@ pub use table::{
     AddPaymentToReservationRequest, CreateCheckoutRequest, CreateCheckoutResponse,
     CreateClubTableRequest, CreatePaymentIntentResponse, CreateSplitPaymentIntentRequest,
     CreateSplitReservationRequest, CreateSplitReservationResponse, CreateTableRequest,
-    CreateTableReservationRequest,
-    LinkTicketToReservationRequest, PaymentLinkPreviewResponse, PaymentShareResponse,
-    ReservationGuest, ReservationPaymentShare, ReservationPaymentStatusResponse, Table,
-    TableReservation, TableReservationResponse, TableReservationWithDetailsResponse,
-    TableReservationsResponse, TableReservationsWithDetailsResponse, TableResponse, TableSummary,
-    TablesResponse, UpdateTableRequest, UpdateTableReservationRequest,
+    CreateTableReservationRequest, LinkTicketToReservationRequest, PaymentLinkPreviewResponse,
+    ReservationPaymentShare, ReservationPaymentStatusResponse, Table, TableReservation,
+    TableReservationResponse, TableReservationWithDetailsResponse, TableReservationsResponse,
+    TableReservationsWithDetailsResponse, TableResponse, TableSummary, TablesResponse,
+    UpdateTableRequest, UpdateTableReservationRequest,
 };
 
 pub mod area;
@@ -46,7 +45,7 @@ pub use area::{Area, AreaResponse, AssignAreaRequest, CreateAreaRequest, UpdateA
 use serde::Deserialize;
 
 #[allow(unused_imports)]
-pub use crate::api::errors::{ApiError, AppError, AppResult};
+pub use crate::api::errors::ApiError;
 #[allow(unused_imports)]
 pub use crate::bootstrap::state::AppState;
 

--- a/rust_BE/src/models/payment.rs
+++ b/rust_BE/src/models/payment.rs
@@ -56,18 +56,6 @@ pub struct PaymentRequest {
     pub idempotency_key: Option<Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PaymentResponse {
-    pub id: Uuid,
-    pub sender_id: Uuid,
-    pub receiver_id: Uuid,
-    pub amount: Decimal,
-    pub insert_date: NaiveDateTime,
-    pub update_date: Option<NaiveDateTime>,
-    pub stripe_payment_intent_id: Option<String>,
-    pub user_ids: Option<Vec<Uuid>>,
-}
-
 #[derive(Debug, serde::Deserialize)]
 pub struct PaymentFilter {
     pub sender_id: Option<i32>,

--- a/rust_BE/src/models/table.rs
+++ b/rust_BE/src/models/table.rs
@@ -145,21 +145,6 @@ pub struct CreateTableReservationRequest {
     pub special_requests: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
-pub struct CreateReservationWithPaymentRequest {
-    pub table_id: String,
-    pub event_id: String,
-    pub owner_user_id: String,
-    pub guest_phone_numbers: Vec<String>,
-    pub payment_amount: f64,
-    pub stripe_payment_intent_id: String,
-    pub contact_name: String,
-    pub contact_email: String,
-    pub contact_phone: String,
-    pub special_requests: Option<String>,
-    pub idempotency_key: Option<Uuid>,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct UpdateTableReservationRequest {
     pub status: Option<String>,
@@ -276,15 +261,6 @@ pub struct TableReservationsWithDetailsResponse {
 // Payment tracking
 // ============================================================================
 
-#[derive(Clone, Debug, Serialize, Deserialize, FromRow)]
-pub struct TableReservationPayment {
-    pub id: Uuid,
-    pub reservation_id: Uuid,
-    pub payment_id: Uuid,
-    pub amount: Decimal,
-    pub created_at: DateTime<Utc>,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct AddPaymentToReservationRequest {
     pub payment_id: String,
@@ -295,14 +271,6 @@ pub struct AddPaymentToReservationRequest {
 // Ticket linking
 // ============================================================================
 
-#[derive(Clone, Debug, Serialize, Deserialize, FromRow)]
-pub struct TableReservationTicket {
-    pub id: Uuid,
-    pub reservation_id: Uuid,
-    pub ticket_id: Uuid,
-    pub created_at: DateTime<Utc>,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct LinkTicketToReservationRequest {
     pub ticket_id: String,
@@ -311,15 +279,6 @@ pub struct LinkTicketToReservationRequest {
 // ============================================================================
 // Payment Intent Creation (for Stripe)
 // ============================================================================
-
-#[derive(Debug, Deserialize, Clone, Serialize)]
-pub struct CreatePaymentIntentRequest {
-    pub table_id: String,
-    pub event_id: String,
-    pub owner_user_id: String,
-    pub guest_phone_numbers: Vec<String>,
-    pub idempotency_key: Option<Uuid>,
-}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -354,19 +313,6 @@ pub struct ReservationPaymentShare {
     pub stripe_checkout_session_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, FromRow)]
-pub struct ReservationGuest {
-    pub id: Uuid,
-    pub reservation_id: Uuid,
-    pub user_id: Option<Uuid>,
-    pub phone_number: String,
-    pub email: Option<String>,
-    pub name: Option<String>,
-    pub added_by: Uuid,
-    pub ticket_id: Option<Uuid>,
-    pub created_at: DateTime<Utc>,
 }
 
 // ============================================================================

--- a/rust_BE/src/services/storage_service.rs
+++ b/rust_BE/src/services/storage_service.rs
@@ -62,10 +62,6 @@ impl StorageService {
         Self { client, cfg }
     }
 
-    pub fn is_configured(&self) -> bool {
-        self.cfg.supabase_url.is_some() && self.cfg.supabase_service_role_key.is_some()
-    }
-
     pub fn max_bytes(&self) -> usize {
         self.cfg.max_panorama_bytes
     }
@@ -77,7 +73,11 @@ impl StorageService {
         content_type: &str,
         body: Vec<u8>,
     ) -> Result<UploadResult, StorageError> {
-        let base_url = self.cfg.supabase_url.as_ref().ok_or(StorageError::NotConfigured)?;
+        let base_url = self
+            .cfg
+            .supabase_url
+            .as_ref()
+            .ok_or(StorageError::NotConfigured)?;
         let service_key = self
             .cfg
             .supabase_service_role_key


### PR DESCRIPTION
## Summary

- Audit dei warning su `cargo check` in `rust_BE/`: da **28 → 0** sul nostro crate (resta solo un future-incompat di `sqlx-postgres v0.7.4`, upstream).
- Rimosso codice morto che mascherava segnale reale: il vecchio envelope `AppError` in competizione con `ApiError` (documentato in CLAUDE.md), un `generate_payment_link_token` duplicato, un `delete_table_image` non-scoped sostituito da `delete_table_image_for_club`, e un blocco di helper split-payment in `table_persistence.rs` superati dal flusso transazionale inline in `reservation_service`.
- 12 file con cambi semantici, 7 file solo `cargo fmt` (pre-esistenti, non più toccabili senza fmt). Net: **+222 / −538** righe.

### Cosa è stato rimosso

| Area | Cosa |
|---|---|
| `api/errors.rs` | `AppError` + 7 costruttori (`validation`, `unauthorized`, `forbidden`, `not_found`, `conflict`, `external_dependency`, `internal`), `AppResult`, impl `From<StatusCode>` / `From<sqlx::Error>` / `IntoResponse`. `ApiError::new` ora calcola direttamente la tupla `(StatusCode, Json<ApiError>)`. |
| `infrastructure/repositories/table_persistence.rs` | 9 fn morte: `add_guest_to_reservation`, `generate_payment_link_token` (duplicato di `table_controller.rs:1114`), `create_payment_share`, `get_payment_share_by_token`, `update_payment_share_paid`, `add_free_guest`, `get_free_guests_by_reservation`, `get_total_people_count`, `increment_reservation_amount_paid`, `update_reservation_num_people`. Helper attivi (`get_reservation_by_payment_link_token`, `get_payment_share_by_checkout_session`, `get_payment_shares_by_reservation`, `set_payment_share_checkout_session`, `check_and_confirm_reservation`) intatti. |
| `models/table.rs` | `CreateReservationWithPaymentRequest`, `TableReservationPayment`, `TableReservationTicket`, `CreatePaymentIntentRequest`, `ReservationGuest`. |
| `models/payment.rs` | `PaymentResponse` (i controller usano `CapturePaymentResponse` / `CancelPaymentResponse`). |
| `infrastructure/repositories/club_owner_persistence.rs` | `delete_table_image` non-scoped (il controller chiama `delete_table_image_for_club`). |
| `infrastructure/repositories/payment_persistence.rs` | `load_payment_by_stripe_id`. |
| `infrastructure/repositories/ticket_persistence.rs` | `get_tickets_by_user_id`. |
| `infrastructure/logging/mod.rs` | `log_business_event`, `log_dependency_event`, `log_security_event`. |
| `services/storage_service.rs` | `StorageService::is_configured`. |

### Cosa è stato annotato

| File | Annotazione | Motivo |
|---|---|---|
| `infrastructure/outbox/mod.rs` | `#[allow(dead_code)]` su `OutboxEvent` | 6 campi popolati da SQLx `FromRow` per diagnostica futura; il dispatcher legge solo `id`, `event_type`, `aggregate_id`, `payload`, `attempts`. |
| `bootstrap/config.rs` | `#[allow(dead_code)]` su `FeatureFlagsConfig.bootstrap_flags_from_env` | Letto da env all'avvio per il futuro provider, nessun consumer attuale. |

## Test plan

- [x] `cd rust_BE && cargo fmt` clean
- [x] `cd rust_BE && cargo check` → 0 warning sul crate locale
- [x] Merge `origin/develop` già allineato (no conflitti)
- [ ] CI verde su PR
- [ ] Smoke locale: `cargo run` parte e healthcheck risponde (lasciato al reviewer; nessuna logica runtime modificata oltre al collassamento di `ApiError::new`, che ha lo stesso output osservabile)

https://claude.ai/code/session_013rqQPYUTJmRqiayAyeXF9t

---
_Generated by [Claude Code](https://claude.ai/code/session_013rqQPYUTJmRqiayAyeXF9t)_